### PR TITLE
Add GET /resume/{id} endpoint

### DIFF
--- a/src/artifactminer/api/retrieval.py
+++ b/src/artifactminer/api/retrieval.py
@@ -7,7 +7,7 @@ All are GET-only with no side effects.
 from datetime import datetime
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from sqlalchemy import or_, func
@@ -227,7 +227,7 @@ async def get_resume_items(
 
 @router.get("/resume/{resume_id}", response_model=ResumeItemResponse)
 async def get_resume_item_by_id(
-    resume_id: int,
+    resume_id: int = Path(..., gt=0),
     db: Session = Depends(get_db),
 ) -> ResumeItemResponse:
     """Retrieve a single resume item by its ID.
@@ -235,28 +235,27 @@ async def get_resume_item_by_id(
     Returns 404 if the item doesn't exist or its associated project is soft-deleted.
     Orphan items (no associated project) are returned with project_name: null.
     """
-    resume_item = db.query(ResumeItem).filter(ResumeItem.id == resume_id).first()
+    result = (
+        db.query(ResumeItem, RepoStat)
+        .outerjoin(RepoStat, ResumeItem.repo_stat_id == RepoStat.id)
+        .filter(ResumeItem.id == resume_id)
+        .first()
+    )
 
-    if resume_item is None:
+    if result is None:
         raise HTTPException(status_code=404, detail="Resume item not found")
 
-    # Check if associated project is soft-deleted
-    if resume_item.repo_stat_id is not None:
-        repo_stat = (
-            db.query(RepoStat).filter(RepoStat.id == resume_item.repo_stat_id).first()
-        )
-        if repo_stat is None or repo_stat.deleted_at is not None:
-            raise HTTPException(status_code=404, detail="Resume item not found")
-        project_name = repo_stat.project_name
-    else:
-        project_name = None
+    resume_item, repo_stat = result
+
+    if repo_stat is not None and repo_stat.deleted_at is not None:
+        raise HTTPException(status_code=404, detail="Resume item not found")
 
     return ResumeItemResponse(
         id=resume_item.id,
         title=resume_item.title,
         content=resume_item.content,
         category=resume_item.category,
-        project_name=project_name,
+        project_name=repo_stat.project_name if repo_stat else None,
         created_at=resume_item.created_at,
     )
 

--- a/tests/api/test_resume_by_id.py
+++ b/tests/api/test_resume_by_id.py
@@ -270,19 +270,17 @@ def test_get_resume_by_id_null_project(client_with_orphan_resume):
 
 
 def test_get_resume_by_id_zero_id(client_with_data):
-    """Returns 404 for ID=0."""
+    """Returns 422 for ID=0 due to Path(gt=0) validation."""
     response = client_with_data.get("/resume/0")
 
-    assert response.status_code == 404
-    assert response.json()["detail"] == "Resume item not found"
+    assert response.status_code == 422
 
 
 def test_get_resume_by_id_negative_id(client_with_data):
-    """Returns 404 for negative IDs."""
+    """Returns 422 for negative IDs due to Path(gt=0) validation."""
     response = client_with_data.get("/resume/-1")
 
-    # FastAPI may return 422 for path validation or 404 if it reaches the handler
-    assert response.status_code in [404, 422]
+    assert response.status_code == 422
 
 
 # === Data Integrity Tests ===


### PR DESCRIPTION
## 📝 Description

Adds a new `GET /resume/{id}` endpoint to retrieve a single resume item by its ID. This enables fetching individual resume items for detailed views or editing workflows.

**Key behaviors:**
- Returns the resume item with associated project name when found
- Returns 404 if the item doesn't exist
- Returns 404 if the associated project is soft-deleted (maintains data consistency)
- Returns the item with `project_name: null` for orphan resume items (no associated project)

**Closes:** #330 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] All 12 tests in `tests/api/test_resume_by_id.py` pass
- [x] Tested success case: `GET /resume/1` returns correct resume item
- [x] Tested 404 case: nonexistent ID returns `{"detail": "Resume item not found"}`
- [x] Tested soft-delete case: resume items with deleted projects return 404
- [x] Tested orphan case: resume items without projects return with `project_name: null`
- [x] Tested invalid ID: string IDs return 422 validation error

Run tests with:
```bash
uv run pytest tests/api/test_resume_by_id.py -v
```

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

Not applicable - API endpoint only, no UI changes.
