### PR TITLE
run Alembic migrations on API startup

### DIFF
--- a/src/artifactminer/api/app.py
+++ b/src/artifactminer/api/app.py
@@ -68,7 +68,8 @@ def create_app() -> FastAPI:
     from alembic.config import Config as AlembicConfig
     from alembic import command as alembic_command
 
-    alembic_cfg = AlembicConfig("alembic.ini")
+    _repo_root = Path(__file__).resolve().parents[3]
+    alembic_cfg = AlembicConfig(str(_repo_root / "alembic.ini"))
     alembic_command.upgrade(alembic_cfg, "head")
 
     # Initialize database schema and seed


### PR DESCRIPTION
## 📝 Description

This PR fixes API startup database initialization so schema changes are always applied via Alembic migrations instead of direct `Base.metadata.create_all(...)`.

Previously, startup could create tables directly from ORM metadata, which bypassed migration history and could drift from expected schema/state for seeded data. That caused inconsistent local DB setup across environments and made migration-driven updates less reliable.

Root cause:
Startup used SQLAlchemy table creation instead of migration application.

Fix:
`create_app()` now runs Alembic `upgrade head` at startup using `alembic.ini`, then continues with existing seed initialization.

This was a root cause for some API calls to not work. 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] `uv run pytest tests/api/test_consent.py tests/api/test_projects_delete.py`
- [x] Result: `17 passed in 0.72s`

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

N/A (backend change)

</details>
