### PR TITLE
Rewrite AppContext for pipeline state

### DIFF
--- a/opentui-react-exp/src/context/AppContext.test.tsx
+++ b/opentui-react-exp/src/context/AppContext.test.tsx
@@ -1,0 +1,242 @@
+import { expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
+import type {
+	PipelineContributorIdentity,
+	PipelineRepoCandidate,
+	PipelineTelemetry,
+	ResumeV3Output,
+} from "../api/types";
+import { AppProvider, useAppState } from "./AppContext";
+
+type AppContextHookValue = ReturnType<typeof useAppState>;
+
+function createHarness() {
+	let context: AppContextHookValue | null = null;
+
+	function Probe() {
+		context = useAppState();
+		return <box />;
+	}
+
+	return {
+		getContext() {
+			if (!context) {
+				throw new Error("AppContext probe did not mount");
+			}
+			return context;
+		},
+		node: (
+			<AppProvider>
+				<Probe />
+			</AppProvider>
+		),
+	};
+}
+
+function destroyRenderer(rendered: { renderer: { destroy: () => void } }) {
+	act(() => {
+		rendered.renderer.destroy();
+	});
+}
+
+const repoCandidate: PipelineRepoCandidate = {
+	id: "repo-1",
+	name: "artifact-miner",
+	rel_path: "artifact-miner",
+};
+
+const contributor: PipelineContributorIdentity = {
+	email: "dev@example.com",
+	name: "Dev Example",
+	repo_count: 1,
+	commit_count: 42,
+	candidate_username: "devexample",
+};
+
+const telemetry: PipelineTelemetry = {
+	stage: "FACTS",
+	active_model: "llama3",
+	repos_total: 3,
+	repos_done: 1,
+	current_repo: "artifact-miner",
+	facts_total: 12,
+	draft_projects: 1,
+	polished_projects: 0,
+	elapsed_seconds: 10,
+	model_check_seconds: 2,
+	selected_repos: ["repo-1"],
+};
+
+const resumeOutput: ResumeV3Output = {
+	professional_summary: "Built reliable developer tooling.",
+	skills_section: "TypeScript, React, Python",
+	developer_profile: "Backend and frontend engineer.",
+	projects: [],
+	metadata: {
+		model_used: "llama3",
+		models_used: ["llama3"],
+		stage: "draft",
+		generation_time_seconds: 12,
+		errors: [],
+		quality_metrics: {},
+	},
+};
+
+test("AppContext exposes the pipeline initial state", async () => {
+	const harness = createHarness();
+	const rendered = await testRender(harness.node, { width: 80, height: 24 });
+
+	expect(harness.getContext().state).toEqual({
+		zipPath: "",
+		intakeId: null,
+		detectedRepos: [],
+		selectedRepoIds: [],
+		contributors: [],
+		selectedEmail: null,
+		pipelineJobId: null,
+		pipelineStatus: "idle",
+		pipelineStage: null,
+		pipelineTelemetry: null,
+		pipelineMessages: [],
+		resumeV3Draft: null,
+		resumeV3Output: null,
+		pipelineNotice: null,
+	});
+
+	destroyRenderer(rendered);
+});
+
+test("AppContext setters update pipeline state", async () => {
+	const harness = createHarness();
+	const rendered = await testRender(harness.node, { width: 80, height: 24 });
+	const context = harness.getContext();
+
+	act(() => {
+		context.setZipPath("/tmp/export.zip");
+		context.setIntakeId("intake-123");
+		context.setDetectedRepos([repoCandidate]);
+		context.setSelectedRepoIds(["repo-1"]);
+		context.setContributors([contributor]);
+		context.setSelectedEmail("dev@example.com");
+		context.setPipelineJobId("job-123");
+		context.setPipelineStatus("running");
+		context.setPipelineStage("FACTS");
+		context.setPipelineTelemetry(telemetry);
+		context.setPipelineMessages(["starting", "processing"]);
+		context.setResumeV3Draft(resumeOutput);
+		context.setResumeV3Output(resumeOutput);
+		context.setPipelineNotice("Ready to continue");
+	});
+
+	expect(harness.getContext().state).toMatchObject({
+		zipPath: "/tmp/export.zip",
+		intakeId: "intake-123",
+		detectedRepos: [repoCandidate],
+		selectedRepoIds: ["repo-1"],
+		contributors: [contributor],
+		selectedEmail: "dev@example.com",
+		pipelineJobId: "job-123",
+		pipelineStatus: "running",
+		pipelineStage: "FACTS",
+		pipelineTelemetry: telemetry,
+		pipelineMessages: ["starting", "processing"],
+		resumeV3Draft: resumeOutput,
+		resumeV3Output: resumeOutput,
+		pipelineNotice: "Ready to continue",
+	});
+
+	destroyRenderer(rendered);
+});
+
+test("resetRunState clears only run-specific pipeline fields", async () => {
+	const harness = createHarness();
+	const rendered = await testRender(harness.node, { width: 80, height: 24 });
+	const context = harness.getContext();
+
+	act(() => {
+		context.setZipPath("/tmp/export.zip");
+		context.setIntakeId("intake-123");
+		context.setDetectedRepos([repoCandidate]);
+		context.setSelectedRepoIds(["repo-1"]);
+		context.setContributors([contributor]);
+		context.setSelectedEmail("dev@example.com");
+		context.setPipelineJobId("job-123");
+		context.setPipelineStatus("draft_ready");
+		context.setPipelineStage("DRAFT");
+		context.setPipelineTelemetry(telemetry);
+		context.setPipelineMessages(["draft ready"]);
+		context.setResumeV3Draft(resumeOutput);
+		context.setResumeV3Output(resumeOutput);
+		context.setPipelineNotice("Use feedback to continue");
+	});
+
+	act(() => {
+		context.resetRunState();
+	});
+
+	expect(harness.getContext().state).toEqual({
+		zipPath: "/tmp/export.zip",
+		intakeId: "intake-123",
+		detectedRepos: [repoCandidate],
+		selectedRepoIds: ["repo-1"],
+		contributors: [contributor],
+		selectedEmail: "dev@example.com",
+		pipelineJobId: null,
+		pipelineStatus: "idle",
+		pipelineStage: null,
+		pipelineTelemetry: null,
+		pipelineMessages: [],
+		resumeV3Draft: null,
+		resumeV3Output: null,
+		pipelineNotice: "Use feedback to continue",
+	});
+
+	destroyRenderer(rendered);
+});
+
+test("reset restores the full initial state", async () => {
+	const harness = createHarness();
+	const rendered = await testRender(harness.node, { width: 80, height: 24 });
+	const context = harness.getContext();
+
+	act(() => {
+		context.setZipPath("/tmp/export.zip");
+		context.setIntakeId("intake-123");
+		context.setDetectedRepos([repoCandidate]);
+		context.setSelectedRepoIds(["repo-1"]);
+		context.setContributors([contributor]);
+		context.setSelectedEmail("dev@example.com");
+		context.setPipelineJobId("job-123");
+		context.setPipelineStatus("complete");
+		context.setPipelineStage("POLISH");
+		context.setPipelineTelemetry(telemetry);
+		context.setPipelineMessages(["done"]);
+		context.setResumeV3Draft(resumeOutput);
+		context.setResumeV3Output(resumeOutput);
+		context.setPipelineNotice("Complete");
+	});
+
+	act(() => {
+		context.reset();
+	});
+
+	expect(harness.getContext().state).toEqual({
+		zipPath: "",
+		intakeId: null,
+		detectedRepos: [],
+		selectedRepoIds: [],
+		contributors: [],
+		selectedEmail: null,
+		pipelineJobId: null,
+		pipelineStatus: "idle",
+		pipelineStage: null,
+		pipelineTelemetry: null,
+		pipelineMessages: [],
+		resumeV3Draft: null,
+		resumeV3Output: null,
+		pipelineNotice: null,
+	});
+
+	destroyRenderer(rendered);
+});

--- a/opentui-react-exp/src/context/AppContext.tsx
+++ b/opentui-react-exp/src/context/AppContext.tsx
@@ -1,49 +1,72 @@
-import { createContext, useContext, useState, type ReactNode } from "react";
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
 import type {
-	AnalysisResponse,
-	ConsentLevel,
-	ResumeItem,
-	Summary,
+	PipelineContributorIdentity,
+	PipelineJobStatus,
+	PipelineRepoCandidate,
+	PipelineStage,
+	PipelineTelemetry,
+	ResumeV3Output,
 } from "../api/types";
 
-export type AnalysisStatus = "idle" | "running" | "complete" | "error";
-
 export interface AppState {
-	consentLevel: ConsentLevel;
-	userEmail: string | null;
-	zipId: number | null;
-	directories: string[];
-	selectedDirectories: string[];
-	analysisResult: AnalysisResponse | null;
-	analysisStatus: AnalysisStatus;
-	resumeItems: ResumeItem[];
-	summaries: Summary[];
+	zipPath: string;
+	intakeId: string | null;
+	detectedRepos: PipelineRepoCandidate[];
+	selectedRepoIds: string[];
+	contributors: PipelineContributorIdentity[];
+	selectedEmail: string | null;
+	pipelineJobId: string | null;
+	pipelineStatus: PipelineJobStatus | "idle";
+	pipelineStage: PipelineStage | null;
+	pipelineTelemetry: PipelineTelemetry | null;
+	pipelineMessages: string[];
+	resumeV3Draft: ResumeV3Output | null;
+	resumeV3Output: ResumeV3Output | null;
+	pipelineNotice: string | null;
 }
 
 interface AppContextValue {
 	state: AppState;
-	setConsentLevel: (value: ConsentLevel) => void;
-	setUserEmail: (value: string | null) => void;
-	setZipId: (value: number | null) => void;
-	setDirectories: (value: string[]) => void;
-	setSelectedDirectories: (value: string[]) => void;
-	setAnalysisResult: (value: AnalysisResponse | null) => void;
-	setAnalysisStatus: (value: AnalysisStatus) => void;
-	setResumeItems: (value: ResumeItem[]) => void;
-	setSummaries: (value: Summary[]) => void;
+	setZipPath: (value: string) => void;
+	setIntakeId: (value: string | null) => void;
+	setDetectedRepos: (value: PipelineRepoCandidate[]) => void;
+	setSelectedRepoIds: (value: string[]) => void;
+	setContributors: (value: PipelineContributorIdentity[]) => void;
+	setSelectedEmail: (value: string | null) => void;
+	setPipelineJobId: (value: string | null) => void;
+	setPipelineStatus: (value: PipelineJobStatus | "idle") => void;
+	setPipelineStage: (value: PipelineStage | null) => void;
+	setPipelineTelemetry: (value: PipelineTelemetry | null) => void;
+	setPipelineMessages: (value: string[]) => void;
+	setResumeV3Draft: (value: ResumeV3Output | null) => void;
+	setResumeV3Output: (value: ResumeV3Output | null) => void;
+	setPipelineNotice: (value: string | null) => void;
+	resetRunState: () => void;
 	reset: () => void;
 }
 
 const initialState: AppState = {
-	consentLevel: "none",
-	userEmail: null,
-	zipId: null,
-	directories: [],
-	selectedDirectories: [],
-	analysisResult: null,
-	analysisStatus: "idle",
-	resumeItems: [],
-	summaries: [],
+	zipPath: "",
+	intakeId: null,
+	detectedRepos: [],
+	selectedRepoIds: [],
+	contributors: [],
+	selectedEmail: null,
+	pipelineJobId: null,
+	pipelineStatus: "idle",
+	pipelineStage: null,
+	pipelineTelemetry: null,
+	pipelineMessages: [],
+	resumeV3Draft: null,
+	resumeV3Output: null,
+	pipelineNotice: null,
 };
 
 const AppContext = createContext<AppContextValue | undefined>(undefined);
@@ -51,45 +74,114 @@ const AppContext = createContext<AppContextValue | undefined>(undefined);
 export function AppProvider({ children }: { children: ReactNode }) {
 	const [state, setState] = useState<AppState>(initialState);
 
-	const setConsentLevel = (value: ConsentLevel) =>
-		setState((prev) => ({ ...prev, consentLevel: value }));
-	const setUserEmail = (value: string | null) =>
-		setState((prev) => ({ ...prev, userEmail: value }));
-	const setZipId = (value: number | null) =>
-		setState((prev) => ({ ...prev, zipId: value }));
-	const setDirectories = (value: string[]) =>
-		setState((prev) => ({ ...prev, directories: value }));
-	const setSelectedDirectories = (value: string[]) =>
-		setState((prev) => ({ ...prev, selectedDirectories: value }));
-	const setAnalysisResult = (value: AnalysisResponse | null) =>
-		setState((prev) => ({ ...prev, analysisResult: value }));
-	const setAnalysisStatus = (value: AnalysisStatus) =>
-		setState((prev) => ({ ...prev, analysisStatus: value }));
-	const setResumeItems = (value: ResumeItem[]) =>
-		setState((prev) => ({ ...prev, resumeItems: value }));
-	const setSummaries = (value: Summary[]) =>
-		setState((prev) => ({ ...prev, summaries: value }));
-	const reset = () => setState(initialState);
-
-	return (
-		<AppContext.Provider
-			value={{
-				state,
-				setConsentLevel,
-				setUserEmail,
-				setZipId,
-				setDirectories,
-				setSelectedDirectories,
-				setAnalysisResult,
-				setAnalysisStatus,
-				setResumeItems,
-				setSummaries,
-				reset,
-			}}
-		>
-			{children}
-		</AppContext.Provider>
+	const setZipPath = useCallback((value: string) => {
+		setState((prev) => ({ ...prev, zipPath: value }));
+	}, []);
+	const setIntakeId = useCallback((value: string | null) => {
+		setState((prev) => ({ ...prev, intakeId: value }));
+	}, []);
+	const setDetectedRepos = useCallback((value: PipelineRepoCandidate[]) => {
+		setState((prev) => ({ ...prev, detectedRepos: value }));
+	}, []);
+	const setSelectedRepoIds = useCallback((value: string[]) => {
+		setState((prev) => ({ ...prev, selectedRepoIds: value }));
+	}, []);
+	const setContributors = useCallback(
+		(value: PipelineContributorIdentity[]) => {
+			setState((prev) => ({ ...prev, contributors: value }));
+		},
+		[],
 	);
+	const setSelectedEmail = useCallback((value: string | null) => {
+		setState((prev) => ({ ...prev, selectedEmail: value }));
+	}, []);
+	const setPipelineJobId = useCallback((value: string | null) => {
+		setState((prev) => ({ ...prev, pipelineJobId: value }));
+	}, []);
+	const setPipelineStatus = useCallback((value: PipelineJobStatus | "idle") => {
+		setState((prev) => ({ ...prev, pipelineStatus: value }));
+	}, []);
+	const setPipelineStage = useCallback((value: PipelineStage | null) => {
+		setState((prev) => ({ ...prev, pipelineStage: value }));
+	}, []);
+	const setPipelineTelemetry = useCallback(
+		(value: PipelineTelemetry | null) => {
+			setState((prev) => ({ ...prev, pipelineTelemetry: value }));
+		},
+		[],
+	);
+	const setPipelineMessages = useCallback((value: string[]) => {
+		setState((prev) => ({ ...prev, pipelineMessages: value }));
+	}, []);
+	const setResumeV3Draft = useCallback((value: ResumeV3Output | null) => {
+		setState((prev) => ({ ...prev, resumeV3Draft: value }));
+	}, []);
+	const setResumeV3Output = useCallback((value: ResumeV3Output | null) => {
+		setState((prev) => ({ ...prev, resumeV3Output: value }));
+	}, []);
+	const setPipelineNotice = useCallback((value: string | null) => {
+		setState((prev) => ({ ...prev, pipelineNotice: value }));
+	}, []);
+
+	const resetRunState = useCallback(
+		() =>
+			setState((prev) => ({
+				...prev,
+				pipelineJobId: null,
+				pipelineStatus: "idle",
+				pipelineStage: null,
+				pipelineTelemetry: null,
+				pipelineMessages: [],
+				resumeV3Draft: null,
+				resumeV3Output: null,
+			})),
+		[],
+	);
+
+	const reset = useCallback(() => setState(initialState), []);
+
+	const value = useMemo(
+		() => ({
+			state,
+			setZipPath,
+			setIntakeId,
+			setDetectedRepos,
+			setSelectedRepoIds,
+			setContributors,
+			setSelectedEmail,
+			setPipelineJobId,
+			setPipelineStatus,
+			setPipelineStage,
+			setPipelineTelemetry,
+			setPipelineMessages,
+			setResumeV3Draft,
+			setResumeV3Output,
+			setPipelineNotice,
+			resetRunState,
+			reset,
+		}),
+		[
+			reset,
+			resetRunState,
+			setContributors,
+			setDetectedRepos,
+			setIntakeId,
+			setPipelineJobId,
+			setPipelineMessages,
+			setPipelineNotice,
+			setPipelineStage,
+			setPipelineStatus,
+			setPipelineTelemetry,
+			setResumeV3Draft,
+			setResumeV3Output,
+			setSelectedEmail,
+			setSelectedRepoIds,
+			setZipPath,
+			state,
+		],
+	);
+
+	return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
 }
 
 export function useAppState() {


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description


This PR rewrites the OpenTUI frontend AppContext to the new pipeline-based state model from the migration plan, replacing the older resume-analysis flow state with pipeline intake, repo selection, contributor identity, job status, telemetry, and draft/output state. It also adds the supporting pipeline API types and includes focused tests for initial state, setter behavior, resetRunState(), and reset(), while keeping the scope limited to context and type changes only.


**Closes:** #424 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

Added tests in [AppContext.test.tsx](/Users/ahmad/capstone-project-team-1-experimental-ollama/opentui-react-exp/src/context/AppContext.test.tsx):

- `AppContext exposes the pipeline initial state`  - Verifies the provider starts with the expected empty pipeline state for intake, selection, job tracking, and outputs.

- `AppContext setters update pipeline state`  - Confirms the main setters correctly populate the new pipeline fields, including repos, contributor identity, telemetry, and resume output.

- `resetRunState clears only run-specific pipeline fields`  - Ensures run-specific data like job status, telemetry, messages, and outputs are cleared without wiping intake and selection state.

- `reset restores the full initial state`  - Verifies a full reset returns the entire context back to its original initial state.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
