### PR TITLE
Add DraftPauseScreen for issue #430

### DIFF
--- a/opentui-react-exp/src/components/DraftPauseScreen.test.tsx
+++ b/opentui-react-exp/src/components/DraftPauseScreen.test.tsx
@@ -1,0 +1,159 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
+import { api } from "../api/endpoints";
+import type { ResumeV3Output } from "../api/types";
+import { AppProvider, useAppState } from "../context/AppContext";
+
+type AppContextHookValue = ReturnType<typeof useAppState>;
+type RenderedScreen = Awaited<ReturnType<typeof testRender>>;
+type KeyboardEventLike = { name: string; sequence?: string; shift?: boolean };
+
+const originalPolishPipeline = api.polishPipeline;
+const originalCancelPipeline = api.cancelPipeline;
+
+let rendered: RenderedScreen | null = null;
+let keyboardHandler: ((key: KeyboardEventLike) => void) | null = null;
+
+mock.module("@opentui/react", () => ({
+	useKeyboard: (handler: (key: KeyboardEventLike) => void) => {
+		keyboardHandler = handler;
+	},
+}));
+
+const { DraftPauseScreen } = await import("./DraftPauseScreen");
+
+const sampleDraft: ResumeV3Output = {
+	professional_summary: "Built reliable platform tooling.",
+	skills_section: "TypeScript, React, Bun",
+	developer_profile: "Engineer focused on developer workflow UX.",
+	projects: [],
+	metadata: {
+		model_used: "llama3",
+		models_used: ["llama3"],
+		stage: "draft",
+		generation_time_seconds: 11,
+		errors: [],
+		quality_metrics: {},
+	},
+};
+
+function createHarness(props?: { onNext?: (target: string) => void }) {
+	let context: AppContextHookValue | null = null;
+
+	function Probe() {
+		context = useAppState();
+		return <DraftPauseScreen onNext={props?.onNext ?? (() => {})} />;
+	}
+
+	return {
+		getContext() {
+			if (!context) {
+				throw new Error("DraftPauseScreen probe did not mount");
+			}
+			return context;
+		},
+		node: (
+			<AppProvider>
+				<Probe />
+			</AppProvider>
+		),
+	};
+}
+
+function destroyRenderer() {
+	if (!rendered) {
+		return;
+	}
+
+	act(() => {
+		rendered?.renderer.destroy();
+	});
+	rendered = null;
+	keyboardHandler = null;
+}
+
+async function seedDraftState(context: AppContextHookValue) {
+	act(() => {
+		context.setPipelineJobId("job-430");
+		context.setResumeV3Draft(sampleDraft);
+		context.setPipelineStatus("draft_ready");
+		context.setPipelineNotice(null);
+	});
+	await rendered?.renderOnce();
+}
+
+async function pressKeyboardShortcut(key: KeyboardEventLike) {
+	if (!keyboardHandler) {
+		throw new Error("DraftPauseScreen keyboard handler was not registered");
+	}
+
+	await act(async () => {
+		keyboardHandler?.(key);
+		await Promise.resolve();
+		await rendered?.renderOnce();
+	});
+}
+
+afterEach(() => {
+	api.polishPipeline = originalPolishPipeline;
+	api.cancelPipeline = originalCancelPipeline;
+	destroyRenderer();
+});
+
+test("DraftPauseScreen renders the paused draft review layout", async () => {
+	const harness = createHarness();
+	rendered = await testRender(harness.node, { width: 140, height: 40 });
+	await seedDraftState(harness.getContext());
+
+	const frame = rendered.captureCharFrame();
+
+	expect(frame).toContain("Stage 2 Pause");
+	expect(frame).toContain("Sections");
+	expect(frame).toContain("Feedback");
+	expect(frame).toContain("Built reliable platform tooling.");
+	expect(frame).toContain("General Notes");
+});
+
+test("DraftPauseScreen moves between draft sections with arrow keys", async () => {
+	const harness = createHarness();
+	rendered = await testRender(harness.node, { width: 140, height: 40 });
+	await seedDraftState(harness.getContext());
+
+	expect(rendered.captureCharFrame()).toContain(
+		"Built reliable platform tooling.",
+	);
+
+	await pressKeyboardShortcut({ name: "down" });
+
+	const frame = rendered.captureCharFrame();
+	expect(frame).toContain("TypeScript, React, Bun");
+	expect(frame).toContain("TECHNICAL SKILLS");
+});
+
+test("DraftPauseScreen cancels the pipeline and updates app state", async () => {
+	let cancelCount = 0;
+	const nextTargets: string[] = [];
+
+	api.cancelPipeline = async () => {
+		cancelCount += 1;
+		return { ok: true, status: "cancelled" };
+	};
+
+	const harness = createHarness({
+		onNext: (target) => {
+			nextTargets.push(target);
+		},
+	});
+	rendered = await testRender(harness.node, { width: 140, height: 40 });
+	await seedDraftState(harness.getContext());
+
+	await pressKeyboardShortcut({ name: "escape" });
+
+	expect(cancelCount).toBe(1);
+	expect(nextTargets).toEqual(["project-list"]);
+	expect(harness.getContext().state.pipelineStatus).toBe("cancelled");
+	expect(harness.getContext().state.pipelineNotice).toBe(
+		"Pipeline cancelled at draft pause.",
+	);
+});

--- a/opentui-react-exp/src/components/DraftPauseScreen.tsx
+++ b/opentui-react-exp/src/components/DraftPauseScreen.tsx
@@ -1,0 +1,319 @@
+import { useKeyboard } from "@opentui/react";
+import { useMemo, useState } from "react";
+import { api } from "../api/endpoints";
+import { useAppState } from "../context/AppContext";
+import { theme } from "../types";
+import { resumeToSections, toErrorMessage } from "../utils";
+import { TopBar } from "./TopBar";
+
+interface DraftPauseScreenProps {
+	onNext: (target: string) => void;
+}
+
+function parseList(value: string): string[] {
+	return value
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+}
+
+function getSectionShortcutIndex(
+	key: { name: string; sequence?: string },
+	sectionCount: number,
+): number | null {
+	const shortcutText = key.sequence ?? key.name;
+	if (!/^[1-9]$/.test(shortcutText)) {
+		return null;
+	}
+
+	const shortcutIndex = Number(shortcutText) - 1;
+	return shortcutIndex < sectionCount ? shortcutIndex : null;
+}
+
+export function DraftPauseScreen({ onNext }: DraftPauseScreenProps) {
+	const { state, setPipelineNotice, setPipelineStatus } = useAppState();
+	const [selectedSection, setSelectedSection] = useState(0);
+	const [focusArea, setFocusArea] = useState<"content" | "feedback">("content");
+	const [focusedField, setFocusedField] = useState(0);
+	const [generalNotes, setGeneralNotes] = useState("");
+	const [tone, setTone] = useState("");
+	const [additionsText, setAdditionsText] = useState("");
+	const [removalsText, setRemovalsText] = useState("");
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [isCancelling, setIsCancelling] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const sections = useMemo(
+		() => resumeToSections(state.resumeV3Draft),
+		[state.resumeV3Draft],
+	);
+
+	const submitFeedback = async () => {
+		if (!state.pipelineJobId) {
+			setError("No active pipeline job.");
+			return;
+		}
+		if (isSubmitting || isCancelling) {
+			return;
+		}
+
+		setError(null);
+		setIsSubmitting(true);
+		try {
+			await api.polishPipeline({
+				general_notes: generalNotes.trim(),
+				tone: tone.trim(),
+				additions: parseList(additionsText),
+				removals: parseList(removalsText),
+			});
+			onNext("analysis");
+		} catch (submitError) {
+			setError(toErrorMessage(submitError));
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const cancelJob = async () => {
+		if (!state.pipelineJobId) {
+			setError("No active pipeline job to cancel.");
+			return;
+		}
+		if (isCancelling || isSubmitting) {
+			return;
+		}
+
+		setIsCancelling(true);
+		setError(null);
+		try {
+			await api.cancelPipeline();
+			setPipelineStatus("cancelled");
+			setPipelineNotice("Pipeline cancelled at draft pause.");
+			onNext("project-list");
+		} catch (cancelError) {
+			setError(toErrorMessage(cancelError));
+		} finally {
+			setIsCancelling(false);
+		}
+	};
+
+	useKeyboard((key) => {
+		if (key.name === "escape") {
+			void cancelJob();
+			return;
+		}
+
+		if (key.name === "return" || key.name === "enter") {
+			void submitFeedback();
+			return;
+		}
+
+		if (key.name === "tab") {
+			setFocusArea((prev) => (prev === "content" ? "feedback" : "content"));
+			return;
+		}
+
+		if (focusArea === "content") {
+			if (key.name === "up") {
+				setSelectedSection((prev) => Math.max(0, prev - 1));
+				return;
+			}
+			if (key.name === "down") {
+				setSelectedSection((prev) => Math.min(sections.length - 1, prev + 1));
+				return;
+			}
+
+			const shortcutIndex = getSectionShortcutIndex(key, sections.length);
+			if (shortcutIndex !== null) {
+				setSelectedSection(shortcutIndex);
+			}
+			return;
+		}
+
+		if (key.name === "up") {
+			setFocusedField((prev) => (prev + 3) % 4);
+			return;
+		}
+		if (key.name === "down") {
+			setFocusedField((prev) => (prev + 1) % 4);
+		}
+	});
+
+	const current = sections[selectedSection] ??
+		sections[0] ?? {
+			id: "empty",
+			headerText: "",
+			tocLabel: "",
+			lines: [],
+		};
+
+	return (
+		<box flexGrow={1} flexDirection="column" backgroundColor={theme.bgDark}>
+			<TopBar
+				step="Draft"
+				title="Stage 2 Pause"
+				description="Review the draft, add feedback, then submit for polish"
+			/>
+
+			<box flexGrow={1} flexDirection="row" gap={1} padding={1}>
+				<box
+					width={22}
+					flexDirection="column"
+					border
+					borderStyle="rounded"
+					borderColor={focusArea === "content" ? theme.gold : theme.goldDim}
+					title="  Sections  "
+					titleAlignment="center"
+					padding={1}
+					gap={1}
+				>
+					{sections.map((section, index) => (
+						<text key={section.id}>
+							<span
+								fg={
+									index === selectedSection ? theme.gold : theme.textSecondary
+								}
+							>
+								{index === selectedSection ? "▶ " : "  "}
+								{index + 1}. {section.tocLabel}
+							</span>
+						</text>
+					))}
+				</box>
+
+				<box
+					flexGrow={1}
+					border
+					borderStyle="rounded"
+					borderColor={focusArea === "content" ? theme.gold : theme.goldDim}
+					title={`  ${current.headerText}  `}
+					titleAlignment="center"
+					padding={1}
+				>
+					<scrollbox
+						focused={focusArea === "content"}
+						key={current.id}
+						style={{
+							rootOptions: { flexGrow: 1, backgroundColor: theme.bgDark },
+							wrapperOptions: { flexGrow: 1 },
+							viewportOptions: { paddingLeft: 1, paddingRight: 1 },
+						}}
+					>
+						{current.lines.map((line, index) => (
+							<text key={`${current.id}-${index}`}>
+								<span fg={theme.textSecondary}>{line || " "}</span>
+							</text>
+						))}
+					</scrollbox>
+				</box>
+
+				<box
+					width={54}
+					border
+					borderStyle="rounded"
+					borderColor={focusArea === "feedback" ? theme.cyan : theme.cyanDim}
+					title="  Feedback  "
+					titleAlignment="center"
+					padding={2}
+					gap={1}
+				>
+					<LabelledInput
+						label="General Notes"
+						value={generalNotes}
+						onChange={setGeneralNotes}
+						focused={focusArea === "feedback" && focusedField === 0}
+						placeholder="e.g. emphasize backend impact"
+					/>
+
+					<LabelledInput
+						label="Tone"
+						value={tone}
+						onChange={setTone}
+						focused={focusArea === "feedback" && focusedField === 1}
+						placeholder="e.g. more technical"
+					/>
+
+					<LabelledInput
+						label="Additions (comma-separated)"
+						value={additionsText}
+						onChange={setAdditionsText}
+						focused={focusArea === "feedback" && focusedField === 2}
+						placeholder="e.g. deployed to production"
+					/>
+
+					<LabelledInput
+						label="Removals (comma-separated)"
+						value={removalsText}
+						onChange={setRemovalsText}
+						focused={focusArea === "feedback" && focusedField === 3}
+						placeholder="e.g. inaccurate ML claim"
+					/>
+
+					<text>
+						<span fg={theme.textDim}>
+							Tab toggles panes · 1-9 jumps sections · ↑/↓ navigates · Enter
+							submits · Esc cancels
+						</span>
+					</text>
+				</box>
+			</box>
+
+			<box
+				paddingLeft={2}
+				paddingRight={2}
+				paddingBottom={1}
+				flexDirection="column"
+				gap={1}
+			>
+				{isSubmitting ? (
+					<text>
+						<span fg={theme.cyan}>
+							Submitting feedback and starting Stage 3...
+						</span>
+					</text>
+				) : null}
+				{isCancelling ? (
+					<text>
+						<span fg={theme.warning}>Cancelling pipeline...</span>
+					</text>
+				) : null}
+				{error ? (
+					<text>
+						<span fg={theme.error}>{error}</span>
+					</text>
+				) : null}
+			</box>
+		</box>
+	);
+}
+
+interface LabelledInputProps {
+	label: string;
+	value: string;
+	onChange: (value: string) => void;
+	focused: boolean;
+	placeholder: string;
+}
+
+function LabelledInput({
+	label,
+	value,
+	onChange,
+	focused,
+	placeholder,
+}: LabelledInputProps) {
+	return (
+		<box flexDirection="column" gap={0}>
+			<text>
+				<span fg={focused ? theme.cyan : theme.textDim}>{label}</span>
+			</text>
+			<input
+				value={value}
+				onChange={onChange}
+				focused={focused}
+				placeholder={placeholder}
+				width={48}
+			/>
+		</box>
+	);
+}


### PR DESCRIPTION
Implement the draft pause screen and basic passing coverage.

<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR adds the new `DraftPauseScreen` component for issue `#430` in `opentui-react-exp`, implementing the paused draft-review screen shown between draft generation and polish. It includes the required 3-column layout, draft section parsing and navigation, inline feedback controls, and pipeline submit/cancel behavior through the migrated app context and API client, while intentionally leaving `index.tsx` wiring out for the later integration PR.

**NOTE** - LOC ran higher than the issue estimate because the screen needed both the full 3-column UI and keyboard-driven interaction logic, plus a small test file for basic coverage. Most of the extra lines are from explicit terminal layout markup and input/navigation handling rather than added feature scope.

**Closes:** #430 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

-  [x] `DraftPauseScreen renders the paused draft review layout`  
  Verifies the screen mounts with the expected draft-pause structure and shows the main UI regions like sections, feedback, and draft content.

- [x] `DraftPauseScreen moves between draft sections with arrow keys`  
  Confirms basic keyboard navigation works for switching the active section in the draft viewer using arrow keys.

-  [x] `DraftPauseScreen cancels the pipeline and updates app state`  
  Checks that cancel triggers `api.cancelPipeline()`, routes back correctly, and updates pipeline status/notice in app state.
---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>