### PR TITLE
feat(local-llm): add stable client surface

### DIFF
--- a/src/artifactminer/local_llm/client.py
+++ b/src/artifactminer/local_llm/client.py
@@ -1,0 +1,129 @@
+"""Stable public client surface for the shared local LLM runtime."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TypeVar
+
+from .models import ModelDescriptor, RuntimeStatus
+from .runtime.config import (
+    DEFAULT_MODEL_NAME,
+    DEFAULT_MODELS_DIR,
+    DEFAULT_STARTUP_TIMEOUT_SECONDS,
+)
+from .runtime.errors import ModelNotFoundError
+from .runtime.inference import query_llm_json as _query_llm_json
+from .runtime.inference import query_llm_text as _query_llm_text
+from .runtime.process_manager import ensure_server as _ensure_server
+from .runtime.process_manager import get_server_status as _get_server_status
+from .runtime.process_manager import stop_server as _stop_server
+from .runtime.registry import list_available_models as _list_available_models
+from .runtime.registry import resolve_model_descriptor as _resolve_model_descriptor
+
+T = TypeVar("T")
+
+__all__ = [
+    "check_model_available",
+    "ensure_model_available",
+    "list_available_models",
+    "query_json",
+    "query_text",
+    "runtime_status",
+    "unload_model",
+]
+
+
+def ensure_model_available(
+    model: str = DEFAULT_MODEL_NAME,
+    *,
+    models_dir: Path = DEFAULT_MODELS_DIR,
+    timeout: float = DEFAULT_STARTUP_TIMEOUT_SECONDS,
+) -> None:
+    """Ensure the requested model is loaded and ready in the local runtime."""
+
+    _ensure_server(model, models_dir=models_dir, timeout=timeout)
+
+
+def check_model_available(
+    model: str = DEFAULT_MODEL_NAME,
+    *,
+    models_dir: Path = DEFAULT_MODELS_DIR,
+) -> bool:
+    """Return whether the requested approved model is installed locally."""
+
+    try:
+        _resolve_model_descriptor(model, models_dir=models_dir)
+    except ModelNotFoundError:
+        return False
+    return True
+
+
+def list_available_models(
+    *,
+    models_dir: Path = DEFAULT_MODELS_DIR,
+) -> list[ModelDescriptor]:
+    """Return the approved models that are currently installed locally."""
+
+    return _list_available_models(models_dir=models_dir)
+
+
+async def query_text(
+    prompt: str,
+    model: str = DEFAULT_MODEL_NAME,
+    *,
+    system: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    top_p: float | None = None,
+    repetition_penalty: float | None = None,
+    grammar: str | None = None,
+) -> str:
+    """Generate plain text through the shared local runtime."""
+
+    return await _query_llm_text(
+        prompt,
+        model=model,
+        system=system,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
+        grammar=grammar,
+    )
+
+
+async def query_json(
+    prompt: str,
+    schema: type[T] | Any,
+    *,
+    model: str = DEFAULT_MODEL_NAME,
+    system: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    top_p: float | None = None,
+    repetition_penalty: float | None = None,
+) -> T:
+    """Generate structured JSON through the shared local runtime."""
+
+    return await _query_llm_json(
+        prompt,
+        schema,
+        model=model,
+        system=system,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
+    )
+
+
+def unload_model() -> None:
+    """Stop the managed local runtime process, if one is active."""
+
+    _stop_server()
+
+
+def runtime_status() -> RuntimeStatus:
+    """Return the current local runtime status snapshot."""
+
+    return _get_server_status()

--- a/tests/local_llm/test_client.py
+++ b/tests/local_llm/test_client.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from artifactminer.local_llm.client import (
+    check_model_available,
+    ensure_model_available,
+    list_available_models,
+    query_json,
+    query_text,
+    runtime_status,
+    unload_model,
+)
+from artifactminer.local_llm.models import ModelDescriptor, RuntimeStatus
+from artifactminer.local_llm.runtime.errors import ModelNotFoundError
+
+
+def test_client_exports_are_stable() -> None:
+    import artifactminer.local_llm.client as client
+
+    assert client.__all__ == [
+        "check_model_available",
+        "ensure_model_available",
+        "list_available_models",
+        "query_json",
+        "query_text",
+        "runtime_status",
+        "unload_model",
+    ]
+
+
+def test_ensure_model_available_delegates_to_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def fake_ensure_server(model: str, *, models_dir: Path, timeout: float) -> None:
+        recorded["model"] = model
+        recorded["models_dir"] = models_dir
+        recorded["timeout"] = timeout
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._ensure_server",
+        fake_ensure_server,
+    )
+
+    ensure_model_available(
+        "qwen3.5-4b-q4",
+        models_dir=Path("/tmp/models"),
+        timeout=12.5,
+    )
+
+    assert recorded == {
+        "model": "qwen3.5-4b-q4",
+        "models_dir": Path("/tmp/models"),
+        "timeout": 12.5,
+    }
+
+
+def test_check_model_available_returns_true_when_model_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_resolve_model_descriptor(model: str, *, models_dir: Path) -> ModelDescriptor:
+        return ModelDescriptor(
+            name=model,
+            filename="model.gguf",
+            context_window=4096,
+            path=models_dir / "model.gguf",
+        )
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._resolve_model_descriptor",
+        fake_resolve_model_descriptor,
+    )
+
+    assert (
+        check_model_available(
+            "qwen2.5-coder-3b-q4",
+            models_dir=Path("/tmp/models"),
+        )
+        is True
+    )
+
+
+def test_check_model_available_returns_false_for_missing_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_resolve_model_descriptor(model: str, *, models_dir: Path) -> ModelDescriptor:
+        raise ModelNotFoundError(model, models_dir / "missing.gguf")
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._resolve_model_descriptor",
+        fake_resolve_model_descriptor,
+    )
+
+    assert (
+        check_model_available(
+            "qwen2.5-coder-3b-q4",
+            models_dir=Path("/tmp/models"),
+        )
+        is False
+    )
+
+
+def test_list_available_models_delegates_to_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = [
+        ModelDescriptor(
+            name="lfm2.5-1.2b-q4",
+            filename="LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
+            context_window=32768,
+            path=Path("/tmp/models/LFM2.5-1.2B-Instruct-Q4_K_M.gguf"),
+        )
+    ]
+
+    def fake_list_available_models(*, models_dir: Path) -> list[ModelDescriptor]:
+        assert models_dir == Path("/tmp/models")
+        return expected
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._list_available_models",
+        fake_list_available_models,
+    )
+
+    assert list_available_models(models_dir=Path("/tmp/models")) == expected
+
+
+@pytest.mark.asyncio
+async def test_query_text_delegates_to_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    async def fake_query_llm_text(
+        prompt: str,
+        *,
+        model: str,
+        system: str | None,
+        temperature: float | None,
+        max_tokens: int | None,
+        top_p: float | None,
+        repetition_penalty: float | None,
+        grammar: str | None,
+    ) -> str:
+        recorded.update(
+            {
+                "prompt": prompt,
+                "model": model,
+                "system": system,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "top_p": top_p,
+                "repetition_penalty": repetition_penalty,
+                "grammar": grammar,
+            }
+        )
+        return "generated text"
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._query_llm_text",
+        fake_query_llm_text,
+    )
+
+    result = await query_text(
+        "hello",
+        model="qwen3.5-4b-q4",
+        system="be concise",
+        temperature=0.4,
+        max_tokens=123,
+        top_p=0.8,
+        repetition_penalty=1.1,
+        grammar='root ::= "ok"',
+    )
+
+    assert result == "generated text"
+    assert recorded == {
+        "prompt": "hello",
+        "model": "qwen3.5-4b-q4",
+        "system": "be concise",
+        "temperature": 0.4,
+        "max_tokens": 123,
+        "top_p": 0.8,
+        "repetition_penalty": 1.1,
+        "grammar": 'root ::= "ok"',
+    }
+
+
+class DemoPayload(BaseModel):
+    name: str
+
+
+@pytest.mark.asyncio
+async def test_query_json_delegates_to_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    async def fake_query_llm_json(
+        prompt: str,
+        schema: type[DemoPayload],
+        *,
+        model: str,
+        system: str | None,
+        temperature: float | None,
+        max_tokens: int | None,
+        top_p: float | None,
+        repetition_penalty: float | None,
+    ) -> DemoPayload:
+        recorded.update(
+            {
+                "prompt": prompt,
+                "schema": schema,
+                "model": model,
+                "system": system,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "top_p": top_p,
+                "repetition_penalty": repetition_penalty,
+            }
+        )
+        return DemoPayload(name="Ada")
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._query_llm_json",
+        fake_query_llm_json,
+    )
+
+    result = await query_json(
+        "return json",
+        DemoPayload,
+        model="qwen2.5-coder-3b-q4",
+        system="json only",
+        temperature=0.2,
+        max_tokens=55,
+        top_p=0.9,
+        repetition_penalty=1.02,
+    )
+
+    assert result == DemoPayload(name="Ada")
+    assert recorded == {
+        "prompt": "return json",
+        "schema": DemoPayload,
+        "model": "qwen2.5-coder-3b-q4",
+        "system": "json only",
+        "temperature": 0.2,
+        "max_tokens": 55,
+        "top_p": 0.9,
+        "repetition_penalty": 1.02,
+    }
+
+
+def test_unload_model_delegates_to_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_state = {"called": False}
+
+    def fake_stop_server() -> None:
+        stop_state["called"] = True
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._stop_server",
+        fake_stop_server,
+    )
+
+    unload_model()
+
+    assert stop_state["called"] is True
+
+
+def test_runtime_status_delegates_to_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = RuntimeStatus(
+        loaded_model="qwen3.5-4b-q4",
+        server_pid=4321,
+        server_port=11434,
+        is_running=True,
+        is_healthy=True,
+        models_dir=Path("/tmp/models"),
+    )
+
+    monkeypatch.setattr(
+        "artifactminer.local_llm.client._get_server_status",
+        lambda: expected,
+    )
+
+    assert runtime_status() == expected


### PR DESCRIPTION
## 📝 Description

Adds a thin `artifactminer.local_llm.client` facade over the new runtime internals so application code has one stable import surface for local runtime operations.

This PR introduces public helpers for model availability checks, runtime status/unload, and async text/JSON querying, plus contract tests that verify the facade delegates to the runtime layer instead of duplicating behavior.

Dependencies: none.

**Closes:** #457

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] `uv run pytest tests/local_llm`
---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

Not Applicable