### PR TITLE
Harden professor setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ flowchart TB
 
     subgraph Data["Data Layer"]
         SQLite[("SQLite")]
-        Uploads[("uploads/")]
-        Extracted[(".extracted/")]
+        Uploads[("~/.artifactminer/uploads/")]
+        Extracted[("~/.artifactminer/extracted/")]
     end
 
     React --> Gateway
@@ -93,7 +93,7 @@ Runs entirely on your machine using [llama.cpp](https://github.com/ggml-org/llam
 - The server loads a GGUF model from `~/.artifactminer/models/`.
 - The pipeline extracts project facts from your repositories, generates a draft resume, and optionally polishes it — all via local inference.
 
-**Model:** Qwen 3.5 2B (Q4_K_M quantization, ~1.5 GB)
+**Default local model:** Qwen 2.5 Coder 3B Instruct (Q4_K_M quantization)
 
 ### Cloud Agent Generation (GitHub Copilot)
 
@@ -173,6 +173,13 @@ uv sync
 
 This creates a virtual environment and installs all Python dependencies automatically.
 
+When the API starts, it now keeps all writable runtime data in `~/.artifactminer/` by default:
+
+- `~/.artifactminer/artifactminer.db` — SQLite database
+- `~/.artifactminer/uploads/` — uploaded ZIPs and thumbnails
+- `~/.artifactminer/extracted/` — extracted repository contents
+- `~/.artifactminer/models/` — local GGUF model files
+
 **Install the frontend:**
 
 ```bash
@@ -230,11 +237,11 @@ Verify on all platforms: `llama-server --version`
 
 #### 3b. Download the model
 
-Download **Qwen3.5-2B-Q4_K_M.gguf** (~1.5 GB) from Hugging Face:
+Download **qwen2.5-coder-3b-instruct-q4_k_m.gguf** from Hugging Face:
 
-> [https://huggingface.co/unsloth/Qwen3.5-2B-GGUF?show_file_info=Qwen3.5-2B-Q4_K_M.gguf](https://huggingface.co/unsloth/Qwen3.5-2B-GGUF?show_file_info=Qwen3.5-2B-Q4_K_M.gguf)
+> [https://huggingface.co/Qwen/Qwen2.5-Coder-3B-Instruct-GGUF?show_file_info=qwen2.5-coder-3b-instruct-q4_k_m.gguf](https://huggingface.co/Qwen/Qwen2.5-Coder-3B-Instruct-GGUF?show_file_info=qwen2.5-coder-3b-instruct-q4_k_m.gguf)
 
-On the Hugging Face page, click the **download** button next to `Qwen3.5-2B-Q4_K_M.gguf`.
+On the Hugging Face page, click the **download** button next to `qwen2.5-coder-3b-instruct-q4_k_m.gguf`.
 
 Then move the file into the Artifact Miner models directory:
 
@@ -242,17 +249,17 @@ Then move the file into the Artifact Miner models directory:
 
 ```bash
 mkdir -p ~/.artifactminer/models
-mv ~/Downloads/Qwen3.5-2B-Q4_K_M.gguf ~/.artifactminer/models/
+mv ~/Downloads/qwen2.5-coder-3b-instruct-q4_k_m.gguf ~/.artifactminer/models/
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.artifactminer\models"
-Move-Item "$env:USERPROFILE\Downloads\Qwen3.5-2B-Q4_K_M.gguf" "$env:USERPROFILE\.artifactminer\models\"
+Move-Item "$env:USERPROFILE\Downloads\qwen2.5-coder-3b-instruct-q4_k_m.gguf" "$env:USERPROFILE\.artifactminer\models\"
 ```
 
-The backend will automatically start and manage `llama-server` when you choose local generation. No manual server startup is needed.
+The backend will automatically start and manage `llama-server` when you choose local generation. No manual server startup is needed, and if you omit model selection the API will automatically use the preferred installed supported model from `~/.artifactminer/models/`.
 
 ### Step 4 — Run the system
 
@@ -262,8 +269,10 @@ You need **two terminals** open — one for the backend API server and one for t
 
 ```bash
 # From the project root directory:
-uv run api
+uv run api run
 ```
+
+`uv run api run` will automatically create `~/.artifactminer/artifactminer.db` if it does not exist and apply the latest Alembic migrations before serving requests.
 
 You should see output like:
 
@@ -275,6 +284,13 @@ Leave this terminal running. The API server is now ready.
 
 You can verify it's working by opening [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) in your browser — this shows the interactive Swagger API documentation.
 
+You can also verify the backend and local-model setup from the terminal:
+
+```bash
+curl http://127.0.0.1:8000/health
+curl http://127.0.0.1:8000/local-llm/setup
+```
+
 #### Terminal 2 — Start the OpenTUI client
 
 Open a **second** terminal window and run:
@@ -282,7 +298,7 @@ Open a **second** terminal window and run:
 ```bash
 cd opentui-react-exp
 bun install
-bun run src/index.tsx
+bun run dev
 ```
 
 The terminal client launches and connects to the backend automatically. You should see the Artifact Miner landing screen.
@@ -314,7 +330,7 @@ Once both terminals are running:
 | `llama-server: command not found` | Make sure llama-server is on your PATH (see Step 3a). Restart your terminal. |
 | Backend fails to start | Make sure port 8000 is not in use. Try `lsof -i :8000` (macOS/Linux) or `netstat -ano \| findstr :8000` (Windows) to check. |
 | TUI shows connection error | Make sure the backend is running in Terminal 1 before starting the TUI in Terminal 2. |
-| Model not found error | Verify `Qwen3.5-2B-Q4_K_M.gguf` is in `~/.artifactminer/models/` (or `%USERPROFILE%\.artifactminer\models\` on Windows). |
+| Model not found error | Verify `qwen2.5-coder-3b-instruct-q4_k_m.gguf` is in `~/.artifactminer/models/` (or `%USERPROFILE%\.artifactminer\models\` on Windows). |
 | Windows terminal renders incorrectly | Use **Windows Terminal** or **PowerShell** instead of `cmd.exe`. |
 | GitHub Copilot login fails | Make sure you have an active GitHub account. Students can get free Copilot access via [GitHub Education](https://education.github.com/). |
 
@@ -433,6 +449,12 @@ src/artifactminer/
   helpers/                Utility functions (project ranker, OpenAI client)
   cli/                    CLI entry point and interactive mode
 
+~/.artifactminer/         Runtime data created automatically by the API
+  artifactminer.db        SQLite database
+  uploads/                Uploaded ZIPs and project thumbnails
+  extracted/              Extracted repository contents
+  models/                 Supported local GGUF model files
+
 opentui-react-exp/        React terminal client (OpenTUI + Pi Agent SDK)
   src/
     api/                  API client and TypeScript interfaces
@@ -488,4 +510,4 @@ uv run alembic downgrade -1
 
 ## Local Model
 
-The local LLM runtime uses **Qwen 3.5 2B** (Q4_K_M quantization). Download `Qwen3.5-2B-Q4_K_M.gguf` from [Hugging Face](https://huggingface.co/unsloth/Qwen3.5-2B-GGUF?show_file_info=Qwen3.5-2B-Q4_K_M.gguf) and place it in `~/.artifactminer/models/`.
+The default OpenTUI local-generation path uses **Qwen 2.5 Coder 3B Instruct** (Q4_K_M quantization). Download `qwen2.5-coder-3b-instruct-q4_k_m.gguf` from [Hugging Face](https://huggingface.co/Qwen/Qwen2.5-Coder-3B-Instruct-GGUF?show_file_info=qwen2.5-coder-3b-instruct-q4_k_m.gguf) and place it in `~/.artifactminer/models/`.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ flowchart LR
     Generate --> Review["Review + edit resume"]
 ```
 
-1. **Consent and configuration** — choose your name, email, and consent level (local LLM, cloud AI, or heuristic-only).
+1. **Consent and configuration** — choose your name, email, and AI mode (local LLM or cloud AI).
 2. **Upload** — select a ZIP archive containing one or more Git repositories.
 3. **Configure** — pick which repositories and identity to use for analysis.
 4. **Generate** — the system analyzes repositories, extracts skills, and generates a structured resume using local or cloud AI. The generated resume is saved to the SQLite database for future retrieval.
@@ -313,7 +313,6 @@ Once both terminals are running:
 2. **Consent** — choose your AI preference:
    - **Local LLM** — uses the Qwen model on your machine (requires Step 3 above).
    - **Cloud (GitHub Copilot)** — uses GitHub Copilot models over the internet (free with GitHub Education).
-   - **No AI** — heuristic-only analysis, no LLM generation.
 3. **File upload** — browse your filesystem and select a ZIP archive containing your project(s). Use arrow keys to navigate, Enter to open folders, and Enter on a `.zip` file to select it.
 4. **Configure** — select which repositories to analyze, enter your name and email, and choose your identity for collaborative projects.
 5. **Generate** — the system analyzes your code and generates a resume.

--- a/opentui-react-exp/src/api/endpoints.test.ts
+++ b/opentui-react-exp/src/api/endpoints.test.ts
@@ -64,6 +64,32 @@ test("getPipelineContributors posts the request payload unchanged", async () => 
 	expect(fetchCalls[0]?.options?.body).toBe(JSON.stringify(request));
 });
 
+test("getLocalLlmSetup performs GET /local-llm/setup", async () => {
+	installMockFetch({
+		models_dir: "/Users/example/.artifactminer/models",
+		preferred_default_model: "qwen2.5-coder-3b-q4",
+		selected_default_model: "qwen2.5-coder-3b-q4",
+		supported_models: [],
+		available_models: [],
+		llama_server_found: true,
+		runtime: {
+			loaded_model: null,
+			server_pid: null,
+			server_port: null,
+			is_running: false,
+			is_healthy: false,
+			models_dir: "/Users/example/.artifactminer/models",
+		},
+	});
+
+	await api.getLocalLlmSetup();
+
+	expect(fetchCalls).toHaveLength(1);
+	expect(fetchCalls[0]?.url).toBe("http://127.0.0.1:8000/local-llm/setup");
+	expect(fetchCalls[0]?.options?.method).toBe("GET");
+	expect(fetchCalls[0]?.options?.body).toBeUndefined();
+});
+
 test("startPipeline posts the request payload unchanged", async () => {
 	installMockFetch({ job_id: "job-1", status: "queued" });
 	const request = {

--- a/opentui-react-exp/src/api/endpoints.ts
+++ b/opentui-react-exp/src/api/endpoints.ts
@@ -11,6 +11,7 @@ import type {
 	Education,
 	EducationCreateRequest,
 	ExtractLocalResponse,
+	LocalLlmSetupResponse,
 	PipelineCancelResponse,
 	PipelineContributorsRequest,
 	PipelineContributorsResponse,
@@ -91,6 +92,8 @@ export const api = {
 		request: PipelineContributorsRequest,
 	): Promise<PipelineContributorsResponse> =>
 		client.post("/local-llm/context/contributors", request),
+	getLocalLlmSetup: (): Promise<LocalLlmSetupResponse> =>
+		client.get("/local-llm/setup"),
 	startPipeline: (
 		request: PipelineStartRequest,
 	): Promise<PipelineStartResponse> =>

--- a/opentui-react-exp/src/api/types.ts
+++ b/opentui-react-exp/src/api/types.ts
@@ -173,14 +173,41 @@ export interface PipelineStartRequest {
 	intake_id?: string | null;
 	repo_ids: string[];
 	user_email: string;
-	stage1_model: string;
-	stage2_model: string;
-	stage3_model: string;
+	stage1_model?: string;
+	stage2_model?: string;
+	stage3_model?: string;
 }
 
 export interface PipelineStartResponse {
 	job_id: string;
 	status: PipelineJobStatus;
+}
+
+export interface LocalLlmModelDescriptor {
+	name: string;
+	filename: string | null;
+	repo_url: string | null;
+	context_window: number | null;
+	path: string | null;
+}
+
+export interface LocalLlmRuntimeStatus {
+	loaded_model: string | null;
+	server_pid: number | null;
+	server_port: number | null;
+	is_running: boolean;
+	is_healthy: boolean;
+	models_dir: string;
+}
+
+export interface LocalLlmSetupResponse {
+	models_dir: string;
+	preferred_default_model: string;
+	selected_default_model: string | null;
+	supported_models: LocalLlmModelDescriptor[];
+	available_models: LocalLlmModelDescriptor[];
+	llama_server_found: boolean;
+	runtime: LocalLlmRuntimeStatus;
 }
 
 export interface ResumeV3ProjectPeriod {

--- a/opentui-react-exp/src/components/PipelineLaunchScreen.test.tsx
+++ b/opentui-react-exp/src/components/PipelineLaunchScreen.test.tsx
@@ -100,6 +100,19 @@ async function flushEffects() {
 	await Promise.resolve();
 }
 
+async function renderScreen(node: ReturnType<typeof createScreenHarness>["node"]) {
+	let rendered: RenderedScreen | null = null;
+	await act(async () => {
+		rendered = await testRender(node, { width: 100, height: 32 });
+		await flushEffects();
+	});
+	if (!rendered) {
+		throw new Error("Failed to render test screen");
+	}
+	await rendered.renderOnce();
+	return rendered;
+}
+
 afterEach(() => {
 	globalThis.fetch = originalFetch;
 	keyboardHandler = null;
@@ -150,7 +163,7 @@ test("PipelineLaunchScreen renders the selected email and repo summary", async (
 			status: 200,
 			headers: { "Content-Type": "application/json" },
 		})) as typeof fetch;
-	const rendered = await testRender(harness.node, { width: 100, height: 32 });
+	const rendered = await renderScreen(harness.node);
 	const context = harness.getContext();
 
 	act(() => {
@@ -160,7 +173,6 @@ test("PipelineLaunchScreen renders the selected email and repo summary", async (
 		context.setSelectedEmail("dev@example.com");
 	});
 
-	await rendered.renderOnce();
 	await act(async () => {
 		await flushEffects();
 	});
@@ -204,7 +216,7 @@ test("PipelineLaunchScreen starts the pipeline on Enter and updates context", as
 		});
 	}) as typeof fetch;
 
-	const rendered = await testRender(harness.node, { width: 100, height: 32 });
+	const rendered = await renderScreen(harness.node);
 	const context = harness.getContext();
 
 	act(() => {
@@ -219,7 +231,6 @@ test("PipelineLaunchScreen starts the pipeline on Enter and updates context", as
 		context.setPipelineNotice("Old notice");
 	});
 
-	await rendered.renderOnce();
 	await act(async () => {
 		await flushEffects();
 	});
@@ -257,7 +268,6 @@ test("PipelineLaunchScreen starts the pipeline on Enter and updates context", as
 
 test("PipelineLaunchScreen shows a validation error instead of launching with missing state", async () => {
 	const harness = createScreenHarness();
-	const rendered = await testRender(harness.node, { width: 100, height: 32 });
 	let fetchCalled = false;
 
 	globalThis.fetch = (async (_input, init) => {
@@ -274,7 +284,7 @@ test("PipelineLaunchScreen shows a validation error instead of launching with mi
 		});
 	}) as unknown as typeof fetch;
 
-	await rendered.renderOnce();
+	const rendered = await renderScreen(harness.node);
 	await act(async () => {
 		await flushEffects();
 	});
@@ -309,7 +319,7 @@ test("PipelineLaunchScreen blocks launch when no supported local model is instal
 			},
 		)) as typeof fetch;
 
-	const rendered = await testRender(harness.node, { width: 100, height: 32 });
+	const rendered = await renderScreen(harness.node);
 	const context = harness.getContext();
 
 	act(() => {
@@ -319,7 +329,6 @@ test("PipelineLaunchScreen blocks launch when no supported local model is instal
 		context.setSelectedEmail("dev@example.com");
 	});
 
-	await rendered.renderOnce();
 	await act(async () => {
 		await flushEffects();
 	});

--- a/opentui-react-exp/src/components/PipelineLaunchScreen.test.tsx
+++ b/opentui-react-exp/src/components/PipelineLaunchScreen.test.tsx
@@ -105,8 +105,51 @@ afterEach(() => {
 	keyboardHandler = null;
 });
 
+function setupResponse(overrides?: Partial<Record<string, unknown>>) {
+	return {
+		models_dir: "/Users/stavan/.artifactminer/models",
+		preferred_default_model: "qwen2.5-coder-3b-q4",
+		selected_default_model: "qwen2.5-coder-3b-q4",
+		supported_models: [
+			{
+				name: "qwen2.5-coder-3b-q4",
+				filename: "qwen2.5-coder-3b-instruct-q4_k_m.gguf",
+				repo_url:
+					"https://huggingface.co/Qwen/Qwen2.5-Coder-3B-Instruct-GGUF?show_file_info=qwen2.5-coder-3b-instruct-q4_k_m.gguf",
+				context_window: 16384,
+				path: null,
+			},
+		],
+		available_models: [
+			{
+				name: "qwen2.5-coder-3b-q4",
+				filename: "qwen2.5-coder-3b-instruct-q4_k_m.gguf",
+				repo_url:
+					"https://huggingface.co/Qwen/Qwen2.5-Coder-3B-Instruct-GGUF?show_file_info=qwen2.5-coder-3b-instruct-q4_k_m.gguf",
+				context_window: 16384,
+				path: "/Users/stavan/.artifactminer/models/qwen2.5-coder-3b-instruct-q4_k_m.gguf",
+			},
+		],
+		llama_server_found: true,
+		runtime: {
+			loaded_model: null,
+			server_pid: null,
+			server_port: null,
+			is_running: false,
+			is_healthy: false,
+			models_dir: "/Users/stavan/.artifactminer/models",
+		},
+		...overrides,
+	};
+}
+
 test("PipelineLaunchScreen renders the selected email and repo summary", async () => {
 	const harness = createScreenHarness();
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify(setupResponse()), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		})) as typeof fetch;
 	const rendered = await testRender(harness.node, { width: 100, height: 32 });
 	const context = harness.getContext();
 
@@ -118,6 +161,10 @@ test("PipelineLaunchScreen renders the selected email and repo summary", async (
 	});
 
 	await rendered.renderOnce();
+	await act(async () => {
+		await flushEffects();
+	});
+	await rendered.renderOnce();
 	const frame = rendered.captureCharFrame();
 
 	expect(frame).toContain("Pipeline Configuration");
@@ -125,6 +172,8 @@ test("PipelineLaunchScreen renders the selected email and repo summary", async (
 	expect(frame).toContain("Selected repos: 2");
 	expect(frame).toContain("- artifact-miner");
 	expect(frame).toContain("- resume-lab");
+	expect(frame).toContain("Detected model: qwen2.5-coder-3b-q4");
+	expect(frame).toContain("llama-server found on PATH");
 
 	destroyRenderer(rendered);
 });
@@ -136,6 +185,25 @@ test("PipelineLaunchScreen starts the pipeline on Enter and updates context", as
 			startedCount += 1;
 		},
 	});
+	const fetchCalls: Array<{ url: string; body?: string }> = [];
+	globalThis.fetch = (async (input, init) => {
+		if (!init?.method || init.method === "GET") {
+			fetchCalls.push({ url: String(input) });
+			return new Response(JSON.stringify(setupResponse()), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+		fetchCalls.push({
+			url: String(input),
+			body: typeof init?.body === "string" ? init.body : undefined,
+		});
+		return new Response(JSON.stringify({ job_id: "job-427", status: "queued" }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}) as typeof fetch;
+
 	const rendered = await testRender(harness.node, { width: 100, height: 32 });
 	const context = harness.getContext();
 
@@ -151,18 +219,10 @@ test("PipelineLaunchScreen starts the pipeline on Enter and updates context", as
 		context.setPipelineNotice("Old notice");
 	});
 
-	const fetchCalls: Array<{ url: string; body?: string }> = [];
-	globalThis.fetch = (async (input, init) => {
-		fetchCalls.push({
-			url: String(input),
-			body: typeof init?.body === "string" ? init.body : undefined,
-		});
-		return new Response(JSON.stringify({ job_id: "job-427", status: "queued" }), {
-			status: 200,
-			headers: { "Content-Type": "application/json" },
-		});
-	}) as typeof fetch;
-
+	await rendered.renderOnce();
+	await act(async () => {
+		await flushEffects();
+	});
 	await rendered.renderOnce();
 	await act(async () => {
 		pressKey("return", "\r");
@@ -172,14 +232,14 @@ test("PipelineLaunchScreen starts the pipeline on Enter and updates context", as
 
 	expect(fetchCalls).toEqual([
 		{
+			url: "http://127.0.0.1:8000/local-llm/setup",
+		},
+		{
 			url: "http://127.0.0.1:8000/local-llm/generation/start",
 			body: JSON.stringify({
 				intake_id: "intake-123",
 				repo_ids: ["repo-1"],
 				user_email: "dev@example.com",
-				stage1_model: "qwen2.5-coder-3b-q4",
-				stage2_model: "lfm2.5-1.2b-q8",
-				stage3_model: "lfm2.5-1.2b-q8",
 			}),
 		},
 	]);
@@ -200,7 +260,13 @@ test("PipelineLaunchScreen shows a validation error instead of launching with mi
 	const rendered = await testRender(harness.node, { width: 100, height: 32 });
 	let fetchCalled = false;
 
-	globalThis.fetch = (async () => {
+	globalThis.fetch = (async (_input, init) => {
+		if (!init?.method || init.method === "GET") {
+			return new Response(JSON.stringify(setupResponse()), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
 		fetchCalled = true;
 		return new Response(JSON.stringify({ job_id: "job-should-not-run", status: "queued" }), {
 			status: 200,
@@ -208,6 +274,10 @@ test("PipelineLaunchScreen shows a validation error instead of launching with mi
 		});
 	}) as unknown as typeof fetch;
 
+	await rendered.renderOnce();
+	await act(async () => {
+		await flushEffects();
+	});
 	await rendered.renderOnce();
 	await act(async () => {
 		pressKey("return", "\r");
@@ -218,6 +288,50 @@ test("PipelineLaunchScreen shows a validation error instead of launching with mi
 	expect(fetchCalled).toBe(false);
 	expect(rendered.captureCharFrame()).toContain(
 		"Missing intake, repo selection, or identity.",
+	);
+
+	destroyRenderer(rendered);
+});
+
+test("PipelineLaunchScreen blocks launch when no supported local model is installed", async () => {
+	const harness = createScreenHarness();
+	globalThis.fetch = (async () =>
+		new Response(
+			JSON.stringify(
+				setupResponse({
+					selected_default_model: null,
+					available_models: [],
+				}),
+			),
+			{
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			},
+		)) as typeof fetch;
+
+	const rendered = await testRender(harness.node, { width: 100, height: 32 });
+	const context = harness.getContext();
+
+	act(() => {
+		context.setIntakeId("intake-123");
+		context.setDetectedRepos(repoCandidates);
+		context.setSelectedRepoIds(["repo-1"]);
+		context.setSelectedEmail("dev@example.com");
+	});
+
+	await rendered.renderOnce();
+	await act(async () => {
+		await flushEffects();
+	});
+	await rendered.renderOnce();
+	await act(async () => {
+		pressKey("return", "\r");
+		await flushEffects();
+	});
+	await rendered.renderOnce();
+
+	expect(rendered.captureCharFrame()).toContain(
+		"No supported local model found in ~/.artifactminer/models.",
 	);
 
 	destroyRenderer(rendered);

--- a/opentui-react-exp/src/components/PipelineLaunchScreen.tsx
+++ b/opentui-react-exp/src/components/PipelineLaunchScreen.tsx
@@ -1,6 +1,7 @@
 import { useKeyboard } from "@opentui/react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api } from "../api/endpoints";
+import type { LocalLlmSetupResponse } from "../api/types";
 import { useAppState } from "../context/AppContext";
 import { theme } from "../types";
 import { toErrorMessage } from "../utils";
@@ -10,10 +11,6 @@ interface PipelineLaunchScreenProps {
 	onStarted: () => void;
 	onBack: () => void;
 }
-
-const DEFAULT_STAGE1_MODEL = "qwen3.5-2b-q4";
-const DEFAULT_STAGE2_MODEL = "qwen3.5-2b-q4";
-const DEFAULT_STAGE3_MODEL = "qwen3.5-2b-q4";
 
 export function PipelineLaunchScreen({
 	onStarted,
@@ -32,6 +29,9 @@ export function PipelineLaunchScreen({
 
 	const [isStarting, setIsStarting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [setup, setSetup] = useState<LocalLlmSetupResponse | null>(null);
+	const [setupError, setSetupError] = useState<string | null>(null);
+	const [isLoadingSetup, setIsLoadingSetup] = useState(true);
 
 	const selectedRepos = useMemo(
 		() =>
@@ -45,6 +45,42 @@ export function PipelineLaunchScreen({
 		Boolean(state.intakeId) &&
 		Boolean(state.selectedEmail) &&
 		state.selectedRepoIds.length > 0;
+	const setupBlocked =
+		setup !== null &&
+		(!setup.llama_server_found || !setup.selected_default_model);
+	const preferredModel =
+		setup?.supported_models.find(
+			(model) => model.name === setup.preferred_default_model,
+		) ?? null;
+
+	useEffect(() => {
+		let ignore = false;
+
+		setIsLoadingSetup(true);
+		setSetupError(null);
+
+		api
+			.getLocalLlmSetup()
+			.then((response) => {
+				if (!ignore) {
+					setSetup(response);
+				}
+			})
+			.catch((loadError) => {
+				if (!ignore) {
+					setSetupError(toErrorMessage(loadError));
+				}
+			})
+			.finally(() => {
+				if (!ignore) {
+					setIsLoadingSetup(false);
+				}
+			});
+
+		return () => {
+			ignore = true;
+		};
+	}, []);
 
 	const startPipeline = async () => {
 		if (!canStart || isStarting || !state.intakeId || !state.selectedEmail) {
@@ -52,6 +88,25 @@ export function PipelineLaunchScreen({
 				setError("Missing intake, repo selection, or identity.");
 			}
 			return;
+		}
+		if (isLoadingSetup) {
+			setError("Still checking local model setup. Try again in a moment.");
+			return;
+		}
+		if (setupBlocked) {
+			if (setup && !setup.llama_server_found) {
+				setError("llama-server is not on PATH. Install llama.cpp first.");
+				return;
+			}
+			if (setup && !setup.selected_default_model) {
+				const missingFile =
+					preferredModel?.filename ??
+					"qwen2.5-coder-3b-instruct-q4_k_m.gguf";
+				setError(
+					`No supported local model found in ~/.artifactminer/models. Expected ${missingFile}.`,
+				);
+				return;
+			}
 		}
 
 		setError(null);
@@ -62,9 +117,6 @@ export function PipelineLaunchScreen({
 				intake_id: state.intakeId,
 				repo_ids: state.selectedRepoIds,
 				user_email: state.selectedEmail,
-				stage1_model: DEFAULT_STAGE1_MODEL,
-				stage2_model: DEFAULT_STAGE2_MODEL,
-				stage3_model: DEFAULT_STAGE3_MODEL,
 			});
 
 			resetRunState();
@@ -131,15 +183,56 @@ export function PipelineLaunchScreen({
 					))}
 
 					<box marginTop={1} flexDirection="column" gap={1}>
-						<text>
-							<span fg={theme.cyan}>Stage 1 model: {DEFAULT_STAGE1_MODEL}</span>
-						</text>
-						<text>
-							<span fg={theme.cyan}>Stage 2 model: {DEFAULT_STAGE2_MODEL}</span>
-						</text>
-						<text>
-							<span fg={theme.cyan}>Stage 3 model: {DEFAULT_STAGE3_MODEL}</span>
-						</text>
+						{isLoadingSetup ? (
+							<text>
+								<span fg={theme.cyan}>Checking local model setup...</span>
+							</text>
+						) : null}
+						{setup ? (
+							<>
+								<text>
+									<span
+										fg={
+											setup.selected_default_model
+												? theme.success
+												: theme.warning
+										}
+									>
+										{setup.selected_default_model
+											? `Detected model: ${setup.selected_default_model}`
+											: "No supported local model detected"}
+									</span>
+								</text>
+								<text>
+									<span
+										fg={
+											setup.llama_server_found ? theme.success : theme.warning
+										}
+									>
+										{setup.llama_server_found
+											? "llama-server found on PATH"
+											: "llama-server missing from PATH"}
+									</span>
+								</text>
+								<text>
+									<span fg={theme.textDim}>Models dir: {setup.models_dir}</span>
+								</text>
+								{!setup.selected_default_model && preferredModel?.filename ? (
+									<text>
+										<span fg={theme.warning}>
+											Install {preferredModel.filename} into ~/.artifactminer/models
+										</span>
+									</text>
+								) : null}
+							</>
+						) : null}
+						{setupError ? (
+							<text>
+								<span fg={theme.warning}>
+									Could not load setup status: {setupError}
+								</span>
+							</text>
+						) : null}
 					</box>
 
 					<box marginTop={1}>

--- a/opentui-react-exp/src/components/cloud-ai/SnakeWithProgress.tsx
+++ b/opentui-react-exp/src/components/cloud-ai/SnakeWithProgress.tsx
@@ -16,6 +16,7 @@ import { generateResume, type ResumeEvent } from "../../agent";
 import { api } from "../../api/endpoints";
 import type {
 	DeveloperProfile,
+	LocalLlmSetupResponse,
 	PipelineStage,
 	PipelineStatusResponse,
 	ResumeV3Output,
@@ -139,9 +140,30 @@ const LOCAL_STAGE_LABELS: Record<PipelineStage, string> = {
 	POLISH: "Polishing with your feedback",
 };
 
-const DEFAULT_STAGE1_MODEL = "qwen3.5-2b-q4";
-const DEFAULT_STAGE2_MODEL = "qwen3.5-2b-q4";
-const DEFAULT_STAGE3_MODEL = "qwen3.5-2b-q4";
+function buildLocalSetupError(setup: LocalLlmSetupResponse): string | null {
+	if (!setup.llama_server_found) {
+		return "Install llama.cpp and make sure `llama-server` is on your PATH before starting local mode.";
+	}
+
+	if (setup.selected_default_model) {
+		return null;
+	}
+
+	const preferredModel =
+		setup.supported_models.find(
+			(model) => model.name === setup.preferred_default_model,
+		) ?? setup.supported_models[0];
+
+	if (!preferredModel) {
+		return `No supported local model is installed. Add a supported GGUF file to ${setup.models_dir}.`;
+	}
+
+	if (preferredModel.repo_url) {
+		return `Download ${preferredModel.filename ?? preferredModel.name} from ${preferredModel.repo_url} and place it in ${setup.models_dir}.`;
+	}
+
+	return `Install ${preferredModel.filename ?? preferredModel.name} in ${setup.models_dir}.`;
+}
 
 // ── Cloud Mode Props ─────────────────────────────────────────────────────────
 
@@ -380,7 +402,7 @@ export function SnakeWithProgress(props: SnakeWithProgressProps) {
 					variant: "error",
 					title: isConnErr ? "Backend Offline" : "Generation Failed",
 					message: isConnErr
-						? "Start the backend: uv run uvicorn artifactminer.api.app:app"
+						? "Start the backend: uv run api run"
 						: msg,
 					duration: 0,
 				});
@@ -516,13 +538,23 @@ export function SnakeWithProgress(props: SnakeWithProgressProps) {
 					setFlowPhase("extracting");
 					pushActivity("system", "Starting local AI pipeline...");
 
+					const setup = await api.getLocalLlmSetup();
+					const setupError = buildLocalSetupError(setup);
+					if (setupError) {
+						throw new Error(setupError);
+					}
+					if (setup.selected_default_model) {
+						pushActivity(
+							"system",
+							`Using local model: ${setup.selected_default_model}`,
+							"done",
+						);
+					}
+
 					const response = await api.startPipeline({
 						intake_id: props.intakeId,
 						repo_ids: props.repoIds,
 						user_email: props.userEmail,
-						stage1_model: DEFAULT_STAGE1_MODEL,
-						stage2_model: DEFAULT_STAGE2_MODEL,
-						stage3_model: DEFAULT_STAGE3_MODEL,
 					});
 
 					if (disposed) return;
@@ -553,7 +585,7 @@ export function SnakeWithProgress(props: SnakeWithProgressProps) {
 					variant: "error",
 					title: isConnErr ? "Backend Offline" : "Pipeline Failed to Start",
 					message: isConnErr
-						? "Start the backend: uv run uvicorn artifactminer.api.app:app"
+						? "Start the backend: uv run api run"
 						: msg,
 					duration: 0,
 				});

--- a/src/artifactminer/api/analyze.py
+++ b/src/artifactminer/api/analyze.py
@@ -27,6 +27,8 @@ from collections.abc import Callable
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from artifactminer.app_paths import EXTRACTION_BASE_DIR
+
 from ..db import get_db
 from ..helpers.zip_utils import safe_extract_zip
 from ..db.models import (
@@ -69,7 +71,6 @@ from ..evidence.extractors import (
 from ..helpers.project_ranker import rank_projects
 
 router = APIRouter(prefix="/analyze", tags=["analysis"])
-EXTRACTION_BASE_DIR = Path("./.extracted")
 
 
 def get_user_email(db: Session) -> str:

--- a/src/artifactminer/api/app.py
+++ b/src/artifactminer/api/app.py
@@ -1,12 +1,14 @@
 """ASGI application exposing Artifact Miner backend services."""
 
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import List
 
 from fastapi import FastAPI, Depends
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
+
+from artifactminer.app_paths import THUMBNAILS_DIR, ensure_app_directories
+from artifactminer.bootstrap import ensure_database_ready
 
 from fastapi import HTTPException
 from email_validator import validate_email, EmailNotValidError
@@ -17,15 +19,7 @@ from .schemas import (
     UserAnswerResponse,
     KeyedAnswersRequest,
 )
-from ..db import (
-    Base,
-    engine,
-    SessionLocal,
-    Question,
-    UserAnswer,
-    get_db,
-    seed_questions,
-)
+from ..db import Question, UserAnswer, get_db
 from .consent import router as consent_router
 from .zip import router as zip_router
 from .projects import router as projects_router
@@ -52,13 +46,14 @@ from .views import router as views_router
 
 def create_app() -> FastAPI:
     """Construct the FastAPI instance so tests or scripts can customize it."""
+    ensure_app_directories()
     app = FastAPI(
         title="Artifact Miner API",
         description="Backend services powering the Artifact Miner TUI.",
         version="0.1.0",
     )
 
-    thumbnails_dir = Path("./uploads/thumbnails")
+    thumbnails_dir = THUMBNAILS_DIR
     thumbnails_dir.mkdir(parents=True, exist_ok=True)
     app.mount(
         "/uploads/thumbnails",
@@ -66,20 +61,7 @@ def create_app() -> FastAPI:
         name="project-thumbnails",
     )
 
-    # Run Alembic migrations on startup to keep the DB schema in sync
-    from alembic.config import Config as AlembicConfig
-    from alembic import command as alembic_command
-
-    _repo_root = Path(__file__).resolve().parents[3]
-    alembic_cfg = AlembicConfig(str(_repo_root / "alembic.ini"))
-    alembic_command.upgrade(alembic_cfg, "head")
-
-    # Initialize database schema and seed
-    db = SessionLocal()
-    try:
-        seed_questions(db)
-    finally:
-        db.close()
+    ensure_database_ready()
 
     @app.get("/health", response_model=HealthStatus, tags=["system"])
     async def healthcheck() -> HealthStatus:

--- a/src/artifactminer/api/local_llm.py
+++ b/src/artifactminer/api/local_llm.py
@@ -35,8 +35,13 @@ from ..local_llm.generation.service import (
     finalize_output,
     generate_project_facts,
 )
-from ..local_llm.runtime.process_manager import stop_server
-from ..local_llm.runtime.registry import list_supported_models
+from ..local_llm.runtime.config import DEFAULT_MODEL_NAME, DEFAULT_MODELS_DIR
+from ..local_llm.runtime.process_manager import get_server_status, stop_server
+from ..local_llm.runtime.registry import (
+    list_available_models,
+    list_supported_models,
+    select_default_model_name,
+)
 from .local_llm_schemas import (
     CancellationResponse,
     ContributorDiscoveryRequest,
@@ -48,6 +53,7 @@ from .local_llm_schemas import (
     GenerationTelemetry,
     IntakeCreateRequest,
     IntakeCreateResponse,
+    LocalLLMSetupResponse,
     PolishRequest,
     PolishResponse,
     RepositoryCandidate,
@@ -288,6 +294,31 @@ def _validate_requested_models(*models: str) -> None:
                 f"Model '{model}' is not a supported local model. "
                 f"Supported model names: {supported_names}."
             )
+
+
+def _resolve_requested_models(*models: str | None) -> tuple[str, ...]:
+    selected_default_model = select_default_model_name(DEFAULT_MODELS_DIR)
+    if selected_default_model is None:
+        preferred = next(
+            (
+                descriptor
+                for descriptor in list_supported_models()
+                if descriptor.name == DEFAULT_MODEL_NAME
+            ),
+            None,
+        )
+        hint = (
+            f" Download {preferred.filename} from {preferred.repo_url}."
+            if preferred and preferred.filename and preferred.repo_url
+            else ""
+        )
+        raise ValueError(
+            "No supported local model is installed. "
+            f"Checked {DEFAULT_MODELS_DIR}."
+            f"{hint}"
+        )
+
+    return tuple(model or selected_default_model for model in models)
 
 
 async def _cancel_superseded_job() -> None:
@@ -533,6 +564,19 @@ async def discover_contributors(
         ) from exc
 
 
+@router.get("/setup", response_model=LocalLLMSetupResponse)
+async def get_local_llm_setup() -> LocalLLMSetupResponse:
+    return LocalLLMSetupResponse(
+        models_dir=str(DEFAULT_MODELS_DIR),
+        preferred_default_model=DEFAULT_MODEL_NAME,
+        selected_default_model=select_default_model_name(DEFAULT_MODELS_DIR),
+        supported_models=list_supported_models(),
+        available_models=list_available_models(DEFAULT_MODELS_DIR),
+        llama_server_found=shutil.which("llama-server") is not None,
+        runtime=get_server_status(),
+    )
+
+
 @router.post("/generation/start", response_model=GenerationStartResponse)
 async def start_generation(
     request: GenerationStartRequest,
@@ -542,11 +586,12 @@ async def start_generation(
     try:
         context = _resolve_context(request.intake_id)
         repo_names, repo_paths = _resolve_repo_paths(context, request.repo_ids)
-        _validate_requested_models(
+        stage1_model, stage2_model, stage3_model = _resolve_requested_models(
             request.stage1_model,
             request.stage2_model,
             request.stage3_model,
         )
+        _validate_requested_models(stage1_model, stage2_model, stage3_model)
         await _cancel_superseded_job()
 
         job_id = str(uuid.uuid4())
@@ -556,9 +601,9 @@ async def start_generation(
             repo_ids=list(request.repo_ids),
             repo_names=repo_names,
             user_email=str(request.user_email),
-            stage1_model=request.stage1_model,
-            stage2_model=request.stage2_model,
-            stage3_model=request.stage3_model,
+            stage1_model=stage1_model,
+            stage2_model=stage2_model,
+            stage3_model=stage3_model,
         )
         _generation_jobs[job_id] = job
         _active_generation_id = job_id

--- a/src/artifactminer/api/local_llm.py
+++ b/src/artifactminer/api/local_llm.py
@@ -297,6 +297,9 @@ def _validate_requested_models(*models: str) -> None:
 
 
 def _resolve_requested_models(*models: str | None) -> tuple[str, ...]:
+    if all(models):
+        return tuple(str(model) for model in models)
+
     selected_default_model = select_default_model_name(DEFAULT_MODELS_DIR)
     if selected_default_model is None:
         preferred = next(

--- a/src/artifactminer/api/local_llm_schemas.py
+++ b/src/artifactminer/api/local_llm_schemas.py
@@ -31,6 +31,8 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
+from artifactminer.local_llm.models import ModelDescriptor, RuntimeStatus
+
 
 # ---------------------------------------------------------------------------
 # Job and stage status types
@@ -175,21 +177,44 @@ class GenerationStartRequest(BaseModel):
     user_email: EmailStr = Field(
         description="User email for attribution and identification"
     )
-    stage1_model: str = Field(
-        default="qwen3.5-2b-q4",
+    stage1_model: str | None = Field(
+        default=None,
         min_length=1,
-        description="Model for analysis stage",
+        description="Optional model for analysis stage. Defaults to the preferred installed local model.",
     )
-    stage2_model: str = Field(
-        default="qwen3.5-2b-q4",
+    stage2_model: str | None = Field(
+        default=None,
         min_length=1,
-        description="Model for resume draft stage",
+        description="Optional model for resume draft stage. Defaults to the preferred installed local model.",
     )
-    stage3_model: str = Field(
-        default="qwen3.5-2b-q4",
+    stage3_model: str | None = Field(
+        default=None,
         min_length=1,
-        description="Model for polish/refinement stage",
+        description="Optional model for polish/refinement stage. Defaults to the preferred installed local model.",
     )
+
+
+class LocalLLMSetupResponse(BaseModel):
+    """Runtime setup and installation details for local model execution."""
+
+    models_dir: str = Field(description="Directory scanned for supported GGUF files.")
+    preferred_default_model: str = Field(
+        description="Preferred local model when it is installed."
+    )
+    selected_default_model: str | None = Field(
+        default=None,
+        description="Installed model that will be used when no explicit model is requested.",
+    )
+    supported_models: list[ModelDescriptor] = Field(
+        description="All supported local models, including download metadata."
+    )
+    available_models: list[ModelDescriptor] = Field(
+        description="Supported local models currently installed on disk."
+    )
+    llama_server_found: bool = Field(
+        description="Whether llama-server was found on the current PATH."
+    )
+    runtime: RuntimeStatus = Field(description="Current local runtime status snapshot.")
 
 
 class GenerationStartResponse(BaseModel):

--- a/src/artifactminer/api/main.py
+++ b/src/artifactminer/api/main.py
@@ -1,14 +1,59 @@
-"""CLI entrypoint for running the FastAPI development server."""
+"""CLI entrypoint for running backend setup tasks and the FastAPI server."""
+
+from __future__ import annotations
+
+import argparse
+
 import uvicorn
 
+from artifactminer.bootstrap import ensure_database_ready
 
-def main():
-    """Run the FastAPI development server with auto-reload."""
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="api",
+        description="Artifact Miner backend utilities",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=("run", "bootstrap"),
+        default="run",
+        help="`run` starts the FastAPI dev server, `bootstrap` only prepares the database.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind the API server to.")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind the API server to.")
+    parser.add_argument(
+        "--reload",
+        dest="reload",
+        action="store_true",
+        default=True,
+        help="Enable auto-reload while developing (default: enabled).",
+    )
+    parser.add_argument(
+        "--no-reload",
+        dest="reload",
+        action="store_false",
+        help="Disable auto-reload.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the FastAPI development server or just bootstrap local state."""
+
+    args = _build_parser().parse_args(argv)
+    ensure_database_ready()
+
+    if args.command == "bootstrap":
+        print("Artifact Miner database is ready.")
+        return
+
     uvicorn.run(
         "artifactminer.api.app:app",
-        host="127.0.0.1",
-        port=8000,
-        reload=True,
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
     )
 
 

--- a/src/artifactminer/api/projects.py
+++ b/src/artifactminer/api/projects.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from artifactminer.app_paths import THUMBNAILS_DIR
+
 from fastapi import Query
 from .schemas import (
     ProjectTimelineItem,
@@ -32,7 +34,6 @@ from ..helpers.project_ranker import rank_projects
 
 
 router = APIRouter(prefix="/projects", tags=["projects"])
-THUMBNAILS_DIR = Path("./uploads/thumbnails")
 MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024 # 5 MB
 ALLOWED_THUMBNAIL_SUFFIXES = {".png", ".jpg", ".jpeg"}
 ALLOWED_THUMBNAIL_CONTENT_TYPES = {"image/png", "image/jpeg"}

--- a/src/artifactminer/api/zip.py
+++ b/src/artifactminer/api/zip.py
@@ -8,6 +8,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
 from sqlalchemy.orm import Session
 
+from artifactminer.app_paths import UPLOADS_DIR
 from artifactminer.api.analyze import extract_zip_to_persistent_location
 from artifactminer.directorycrawler import directory_walk
 
@@ -20,9 +21,6 @@ from .schemas import (
     ExtractLocalResponse,
 )
 from ..db import UploadedZip, get_db
-
-
-UPLOADS_DIR = Path("./uploads")
 
 
 router = APIRouter(prefix="/zip", tags=["zip"])

--- a/src/artifactminer/app_paths.py
+++ b/src/artifactminer/app_paths.py
@@ -1,0 +1,38 @@
+"""Shared writable-path configuration for Artifact Miner runtime data."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _expand_path(value: str | Path) -> Path:
+    return Path(value).expanduser()
+
+
+APP_HOME = _expand_path(
+    os.getenv("ARTIFACTMINER_HOME", Path.home() / ".artifactminer")
+)
+UPLOADS_DIR = _expand_path(
+    os.getenv("ARTIFACTMINER_UPLOADS_DIR", APP_HOME / "uploads")
+)
+THUMBNAILS_DIR = _expand_path(
+    os.getenv("ARTIFACTMINER_THUMBNAILS_DIR", UPLOADS_DIR / "thumbnails")
+)
+EXTRACTION_BASE_DIR = _expand_path(
+    os.getenv("ARTIFACTMINER_EXTRACTION_DIR", APP_HOME / "extracted")
+)
+MODELS_DIR = _expand_path(
+    os.getenv("ARTIFACTMINER_MODELS_DIR", APP_HOME / "models")
+)
+DATABASE_FILE = _expand_path(
+    os.getenv("ARTIFACTMINER_DB_FILE", APP_HOME / "artifactminer.db")
+)
+DATABASE_URL = os.getenv("ARTIFACTMINER_DB", f"sqlite:///{DATABASE_FILE}")
+
+
+def ensure_app_directories() -> None:
+    """Create the writable directories the app expects to exist."""
+
+    for path in (APP_HOME, UPLOADS_DIR, THUMBNAILS_DIR, EXTRACTION_BASE_DIR, MODELS_DIR):
+        path.mkdir(parents=True, exist_ok=True)

--- a/src/artifactminer/bootstrap.py
+++ b/src/artifactminer/bootstrap.py
@@ -1,0 +1,27 @@
+"""Shared startup helpers for preparing the local database state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from artifactminer.app_paths import ensure_app_directories
+from artifactminer.db import SessionLocal, seed_questions
+
+
+def ensure_database_ready() -> None:
+    """Create writable directories, apply migrations, and seed baseline rows."""
+
+    ensure_app_directories()
+
+    from alembic import command as alembic_command
+    from alembic.config import Config as AlembicConfig
+
+    repo_root = Path(__file__).resolve().parents[2]
+    alembic_cfg = AlembicConfig(str(repo_root / "alembic.ini"))
+    alembic_command.upgrade(alembic_cfg, "head")
+
+    db = SessionLocal()
+    try:
+        seed_questions(db)
+    finally:
+        db.close()

--- a/src/artifactminer/db/database.py
+++ b/src/artifactminer/db/database.py
@@ -1,7 +1,19 @@
+from pathlib import Path
+
 from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./artifactminer.db"
+from artifactminer.app_paths import DATABASE_URL, ensure_app_directories
+
+
+ensure_app_directories()
+
+SQLALCHEMY_DATABASE_URL = DATABASE_URL
+
+_url = make_url(SQLALCHEMY_DATABASE_URL)
+if _url.get_backend_name() == "sqlite" and _url.database not in (None, "", ":memory:"):
+    Path(_url.database).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
 
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}

--- a/src/artifactminer/local_llm/generation/schemas.py
+++ b/src/artifactminer/local_llm/generation/schemas.py
@@ -26,6 +26,53 @@ class ProjectFacts(BaseModel):
     first_commit: str | None = Field(default=None)
     last_commit: str | None = Field(default=None)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _repair_common_llm_shape_errors(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        payload = dict(value)
+
+        def _coerce_list(field_name: str) -> None:
+            raw_value = payload.get(field_name)
+            if isinstance(raw_value, str):
+                lines = [
+                    line.strip().lstrip("-* ").strip()
+                    for line in raw_value.splitlines()
+                    if line.strip()
+                ]
+                if not lines and raw_value.strip():
+                    lines = [part.strip() for part in raw_value.split(",") if part.strip()]
+                payload[field_name] = lines
+
+        for alias in ("Summary", "project_summary", "description", "overview"):
+            if alias in payload and not payload.get("summary"):
+                payload["summary"] = payload[alias]
+                break
+
+        for field_name in ("technologies", "highlights", "evidence", "frameworks"):
+            _coerce_list(field_name)
+
+        summary = payload.get("summary")
+        if isinstance(summary, str):
+            payload["summary"] = summary.strip()
+
+        if not payload.get("summary"):
+            highlights = payload.get("highlights")
+            evidence = payload.get("evidence")
+            if isinstance(highlights, list) and highlights:
+                payload["summary"] = str(highlights[0]).strip()
+            elif isinstance(evidence, list) and evidence:
+                payload["summary"] = str(evidence[0]).strip()
+            elif payload.get("project_type"):
+                payload["summary"] = (
+                    f"{str(payload['project_name']).strip() or 'This project'} "
+                    f"is a {str(payload['project_type']).strip()}."
+                )
+
+        return payload
+
 
 class ResumeProjectPeriod(BaseModel):
     model_config = ConfigDict(extra="ignore")

--- a/src/artifactminer/local_llm/generation/service.py
+++ b/src/artifactminer/local_llm/generation/service.py
@@ -27,7 +27,14 @@ from .prompts import (
     build_project_facts_prompt,
     build_summary_prompt,
 )
-from .schemas import GenerationFeedback, ProjectFacts, ResumeOutputModel, ResumeProjectModel, ResumeProjectPeriod
+from .schemas import (
+    GenerationFeedback,
+    ProjectFacts,
+    ResumeOutputModel,
+    ResumePortfolioModel,
+    ResumeProjectModel,
+    ResumeProjectPeriod,
+)
 
 
 ProgressCallback = Callable[[str], None]
@@ -208,7 +215,10 @@ def _normalize_output(
         normalized_projects.append(project)
 
     output.projects = normalized_projects
-    output.portfolio = output.portfolio or _build_portfolio_summary(facts)
+    if output.portfolio is None:
+        output.portfolio = ResumePortfolioModel.model_validate(
+            _build_portfolio_summary(facts)
+        )
     output.metadata.stage = stage
     output.metadata.models_used = list(models_used)
     output.metadata.model_used = models_used[-1] if models_used else None

--- a/src/artifactminer/local_llm/runtime/config.py
+++ b/src/artifactminer/local_llm/runtime/config.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import platform
-from pathlib import Path
+
+from artifactminer.app_paths import MODELS_DIR
 
 from ..models import InferenceOptions
 
-DEFAULT_MODEL_NAME = "qwen3.5-2b-q4"
-DEFAULT_MODELS_DIR = Path.home() / ".artifactminer" / "models"
+DEFAULT_MODEL_NAME = "qwen2.5-coder-3b-q4"
+DEFAULT_MODELS_DIR = MODELS_DIR
 DEFAULT_STARTUP_TIMEOUT_SECONDS = 60.0
 DEFAULT_HEALTH_TIMEOUT_SECONDS = 60.0
 DEFAULT_CONTEXT_WINDOW = 4096
-DEFAULT_MAX_TOKENS = 2048
+DEFAULT_MAX_TOKENS = 12288
 
 MODEL_FAMILY_SAMPLING_DEFAULTS: dict[str, InferenceOptions] = {
     "lfm2.5": InferenceOptions(
@@ -27,8 +28,8 @@ MODEL_FAMILY_SAMPLING_DEFAULTS: dict[str, InferenceOptions] = {
         max_tokens=DEFAULT_MAX_TOKENS,
     ),
     "qwen3": InferenceOptions(
-        temperature=0.7,
-        top_p=0.8,
+        temperature=0.2,
+        top_p=0.9,
         max_tokens=DEFAULT_MAX_TOKENS,
     ),
     "fallback": InferenceOptions(

--- a/src/artifactminer/local_llm/runtime/registry.py
+++ b/src/artifactminer/local_llm/runtime/registry.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from types import MappingProxyType
 
 from ..models import ModelDescriptor
-from .config import DEFAULT_MODELS_DIR
+from .config import DEFAULT_MODEL_NAME, DEFAULT_MODELS_DIR
 from .errors import ModelNotFoundError
 
 
@@ -16,12 +16,6 @@ from .errors import ModelNotFoundError
 # filenames so builders do not have to redownload the same weights.
 _SUPPORTED_MODELS = MappingProxyType(
     {
-        "qwen3.5-2b-q4": ModelDescriptor(
-            name="qwen3.5-2b-q4",
-            filename="Qwen3.5-2B-Q4_K_M.gguf",
-            repo_url="https://huggingface.co/Qwen/Qwen3.5-2B",
-            context_window=20480,
-        ),
         "qwen3.5-4b-q4": ModelDescriptor(
             name="qwen3.5-4b-q4",
             filename="Qwen3.5-4B-Q4_K_M.gguf",
@@ -59,7 +53,15 @@ __all__ = [
     "list_supported_models",
     "resolve_model_descriptor",
     "resolve_model_path",
+    "select_default_model_name",
 ]
+
+_DEFAULT_SELECTION_ORDER = (
+    DEFAULT_MODEL_NAME,
+    "qwen3.5-4b-q4",
+    "lfm2.5-1.2b-q4",
+    "lfm2.5-1.2b-q8",
+)
 
 
 def list_supported_models() -> list[ModelDescriptor]:
@@ -111,6 +113,20 @@ def resolve_model_path(model: str, models_dir: Path = DEFAULT_MODELS_DIR) -> Pat
     if descriptor.path is None:
         raise RuntimeError(f"Resolved model '{model}' did not include a path.")
     return descriptor.path
+
+
+def select_default_model_name(models_dir: Path = DEFAULT_MODELS_DIR) -> str | None:
+    """Return the preferred installed local model name, if one is available."""
+
+    available_names = {descriptor.name for descriptor in list_available_models(models_dir)}
+    if not available_names:
+        return None
+
+    for model_name in _DEFAULT_SELECTION_ORDER:
+        if model_name in available_names:
+            return model_name
+
+    return sorted(available_names)[0]
 
 
 def _require_filename(model_name: str, descriptor: ModelDescriptor) -> str:

--- a/src/artifactminer/main.py
+++ b/src/artifactminer/main.py
@@ -5,6 +5,7 @@ import asyncio
 import sys
 from pathlib import Path
 
+from artifactminer.bootstrap import ensure_database_ready
 from artifactminer.cli.prompts import validate_input_path, validate_output_path
 from artifactminer.cli.selection import parse_selection
 
@@ -12,6 +13,8 @@ __all__ = ["parse_selection"]
 
 
 def main() -> None:
+    ensure_database_ready()
+
     parser = argparse.ArgumentParser(
         prog="artifactminer",
         description="Analyze student project portfolios and generate resumes",
@@ -67,4 +70,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/tests/api/test_local_llm.py
+++ b/tests/api/test_local_llm.py
@@ -3,7 +3,18 @@
 import uuid
 from zipfile import ZipFile
 
+import pytest
+
 from artifactminer.api import local_llm
+
+
+@pytest.fixture(autouse=True)
+def _mock_default_local_model(monkeypatch):
+    monkeypatch.setattr(
+        local_llm,
+        "select_default_model_name",
+        lambda _models_dir: "qwen2.5-coder-3b-q4",
+    )
 
 
 def test_local_llm_router_is_registered(client):

--- a/tests/api/test_local_llm.py
+++ b/tests/api/test_local_llm.py
@@ -667,6 +667,46 @@ def test_generation_start_valid_request(client, tmp_path):
     assert data["job_id"] in local_llm._generation_jobs
 
 
+def test_generation_start_uses_installed_default_model_when_omitted(
+    client, tmp_path, monkeypatch
+):
+    """Test that omitted stage models resolve to the preferred installed model."""
+    zip_path = tmp_path / "generation_start_default_model.zip"
+
+    with ZipFile(zip_path, 'w') as zf:
+        zf.writestr("repo-one/.git/config", "[core]")
+        zf.writestr("repo-one/.git/HEAD", "ref: refs/heads/main")
+
+    monkeypatch.setattr(
+        local_llm,
+        "select_default_model_name",
+        lambda _models_dir: "qwen2.5-coder-3b-q4",
+    )
+
+    intake_response = client.post(
+        "/local-llm/context",
+        json={"zip_path": str(zip_path)}
+    )
+    assert intake_response.status_code == 200
+    intake_data = intake_response.json()
+
+    response = client.post(
+        "/local-llm/generation/start",
+        json={
+            "intake_id": intake_data["intake_id"],
+            "repo_ids": [intake_data["repos"][0]["id"]],
+            "user_email": "developer@example.com",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    job = local_llm._generation_jobs[data["job_id"]]
+    assert job["stage1_model"] == "qwen2.5-coder-3b-q4"
+    assert job["stage2_model"] == "qwen2.5-coder-3b-q4"
+    assert job["stage3_model"] == "qwen2.5-coder-3b-q4"
+
+
 def test_generation_start_invalid_email(client, tmp_path):
     """Test 422 response when user_email is invalid."""
     zip_path = tmp_path / "invalid_email.zip"

--- a/tests/api/test_local_llm_routes.py
+++ b/tests/api/test_local_llm_routes.py
@@ -9,6 +9,15 @@ import pytest
 from artifactminer.api import local_llm
 
 
+@pytest.fixture(autouse=True)
+def _mock_default_local_model(monkeypatch):
+    monkeypatch.setattr(
+        local_llm,
+        "select_default_model_name",
+        lambda _models_dir: "qwen2.5-coder-3b-q4",
+    )
+
+
 def make_fake_git_zip() -> str:
     """Create a temporary ZIP containing a minimal fake git repo structure.
 

--- a/tests/api/test_local_llm_routes.py
+++ b/tests/api/test_local_llm_routes.py
@@ -42,6 +42,7 @@ def test_openapi_exposes_all_local_llm_routes(client):
     expected = {
         "/local-llm/context": {"post"},
         "/local-llm/context/contributors": {"post"},
+        "/local-llm/setup": {"get"},
         "/local-llm/generation/start": {"post"},
         "/local-llm/generation/cancel": {"post"},
         "/local-llm/generation/status": {"get"},

--- a/tests/api/test_local_llm_schemas.py
+++ b/tests/api/test_local_llm_schemas.py
@@ -147,9 +147,9 @@ class TestGenerationStartRequest:
             repo_ids=["repo-1"], user_email="user@example.com"
         )
         assert req.intake_id is None
-        assert req.stage1_model == "qwen3.5-2b-q4"
-        assert req.stage2_model == "qwen3.5-2b-q4"
-        assert req.stage3_model == "qwen3.5-2b-q4"
+        assert req.stage1_model is None
+        assert req.stage2_model is None
+        assert req.stage3_model is None
 
     def test_with_intake_id(self):
         req = GenerationStartRequest(

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from artifactminer.api.main import main
+
+
+def test_api_cli_defaults_to_run_command(monkeypatch) -> None:
+    recorded: dict[str, object] = {}
+
+    def fake_run(app: str, *, host: str, port: int, reload: bool) -> None:
+        recorded.update(
+            {
+                "app": app,
+                "host": host,
+                "port": port,
+                "reload": reload,
+            }
+        )
+
+    monkeypatch.setattr("artifactminer.api.main.uvicorn.run", fake_run)
+
+    main([])
+
+    assert recorded == {
+        "app": "artifactminer.api.app:app",
+        "host": "127.0.0.1",
+        "port": 8000,
+        "reload": True,
+    }
+
+
+def test_api_cli_accepts_explicit_run_command_and_overrides(monkeypatch) -> None:
+    recorded: dict[str, object] = {}
+
+    def fake_run(app: str, *, host: str, port: int, reload: bool) -> None:
+        recorded.update(
+            {
+                "app": app,
+                "host": host,
+                "port": port,
+                "reload": reload,
+            }
+        )
+
+    monkeypatch.setattr("artifactminer.api.main.uvicorn.run", fake_run)
+
+    main(["run", "--host", "0.0.0.0", "--port", "8011", "--no-reload"])
+
+    assert recorded == {
+        "app": "artifactminer.api.app:app",
+        "host": "0.0.0.0",
+        "port": 8011,
+        "reload": False,
+    }

--- a/tests/local_llm/test_generation_schemas.py
+++ b/tests/local_llm/test_generation_schemas.py
@@ -1,0 +1,34 @@
+from artifactminer.local_llm.generation.schemas import ProjectFacts
+
+
+def test_project_facts_accepts_description_alias_and_string_lists() -> None:
+    facts = ProjectFacts.model_validate(
+        {
+            "project_name": "artifact-miner",
+            "project_type": "cli tool",
+            "description": "CLI for mining project artifacts into resume facts.",
+            "technologies": "Python\nFastAPI\nSQLite",
+            "highlights": "- Built pipeline orchestration\n- Added local setup checks",
+            "evidence": "README.md\nsrc/artifactminer/api/main.py",
+        }
+    )
+
+    assert facts.summary == "CLI for mining project artifacts into resume facts."
+    assert facts.technologies == ["Python", "FastAPI", "SQLite"]
+    assert facts.highlights == [
+        "Built pipeline orchestration",
+        "Added local setup checks",
+    ]
+    assert facts.evidence == ["README.md", "src/artifactminer/api/main.py"]
+
+
+def test_project_facts_derives_summary_from_highlights_when_missing() -> None:
+    facts = ProjectFacts.model_validate(
+        {
+            "project_name": "artifact-miner",
+            "project_type": "api service",
+            "highlights": ["Built automatic database bootstrap"],
+        }
+    )
+
+    assert facts.summary == "Built automatic database bootstrap"


### PR DESCRIPTION
## 📝 Description

This PR hardens the professor setup flow so a fresh user can run the backend and OpenTUI with fewer manual recovery steps and clearer diagnostics.

Key updates include:
- standardized runtime paths under `~/.artifactminer` via shared path/bootstrap helpers
- API startup hardening (`uv run api run` / `uv run api bootstrap`) with automatic migration + seed prep
- local LLM setup visibility via `/local-llm/setup` and default-model auto-selection behavior
- OpenTUI preflight checks before launching local generation to fail early when `llama-server` or model files are missing
- schema resilience for common small-model JSON shape issues in local generation
- README setup updates for `uv`, `bun`, `llama-server`, and the exact Qwen GGUF flow
- test coverage additions/updates for API CLI, local LLM setup, schema repair, and OpenTUI launch behavior

Root cause of setup friction:
- setup assumptions were split across backend/frontend/docs and not enforced at startup boundaries, so new users encountered late failures after already entering the flow.

User/developer impact:
- professors and first-time users get deterministic startup and clearer local-model guidance
- contributors now have tighter tests around startup + local generation setup contracts

**Closes:** N/A

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [x] `uv run pytest tests/api/test_main.py tests/local_llm/test_registry.py tests/local_llm/test_runtime_primitives.py tests/api/test_local_llm.py tests/api/test_local_llm_routes.py -q`
- [x] `cd opentui-react-exp && bun test src/components/PipelineLaunchScreen.test.tsx src/api/client.test.ts src/api/endpoints.test.ts`
- [x] Manual backend verification:
  - `uv run api --help`
  - `ARTIFACTMINER_HOME=$(mktemp -d) uv run api bootstrap`
  - `uv run api run --port 8010 --no-reload`
  - `curl http://127.0.0.1:8010/health`
  - `curl http://127.0.0.1:8010/local-llm/setup`
- [x] Manual local-generation verification against sample ZIP reached `draft_ready`.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

No screenshots included (TUI/API setup hardening changes).

</details>
